### PR TITLE
HOSTSD-146 Add CI/CD

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -1,0 +1,106 @@
+name: CD/CD Pipeline to DEV
+env:
+  # Artifactory - can't get this to work yet
+  # DOCKER_ARTIFACTORY_REPO: artifacts.developer.gov.bc.ca/docker-remote
+  # ARTIFACTORY_REPO: artifacts.developer.gov.bc.ca
+  # IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+  # IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
+  # IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
+
+  # Registries such as GHCR, Quay.io, and Docker Hub are supported.
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  IMAGE_REGISTRY_USER: ${{ github.actor }}
+  IMAGE_REGISTRY_PASSWORD: ${{ github.token }}
+
+  API_IMAGE_NAME: api
+  APP_IMAGE_NAME: dashboard
+  DB_MIGRATION_IMAGE_NAME: db-migration
+
+  IMAGE_TAG: latest
+  DEPLOY_TO: dev
+  VERSION: 1.0.0
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+      - main
+    types:
+      - closed
+  # push:
+  #   branches:
+  #     - dev
+  #     - main
+
+jobs:
+  build-push:
+    name: Build and Push to Registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+        ## BUILD
+      - name: Build API
+        id: build-api
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ github.repository }}/${{ env.API_IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAG }} ${{ env.VERSION }} ${{ env.DEPLOY_TO }}
+          context: .
+          dockerfiles: |
+            src/api/Dockerfile
+
+      - name: Build Dasbhoard
+        id: build-app
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ github.repository }}/${{ env.APP_IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAG }} ${{ env.VERSION }} ${{ env.DEPLOY_TO }}
+          context: src/dashboard
+          dockerfiles: |
+            src/dashboard/Dockerfile.prod
+
+      - name: Build DB Migration
+        id: build-db-migration
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ github.repository }}/${{ env.DB_MIGRATION_IMAGE_NAME }}
+          tags: ${{ env.IMAGE_TAG }} ${{ env.VERSION }} ${{ env.DEPLOY_TO }}
+          context: src/libs
+          dockerfiles: |
+            src/libs/Dockerfile
+
+        ## PUSH TO REGISTRY
+      - name: Push API to registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ github.repository }}/${{ env.DB_MIGRATION_IMAGE_NAME }}
+          tags: ${{ steps.build-api.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.IMAGE_REGISTRY_USER }}
+          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+
+      - name: Push Dashboard to registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-app.outputs.image }}
+          tags: ${{ steps.build-app.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.IMAGE_REGISTRY_USER }}
+          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+
+      - name: Push DB Migration to registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-db-migration.outputs.image }}
+          tags: ${{ steps.build-db-migration.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ env.IMAGE_REGISTRY_USER }}
+          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       working-directory: ./
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
           # User defined upload name. Visible in Codecov UI
           name: HSB-Dashboard
           # Repository upload token - get it from codecov.io. Required only for private repositories
-          token: ${{env.codecov-token}}
+          token: ${{env.CODECOV_TOKEN}}
           # Path to coverage file to upload
           file: ${{env.working-directory}}/TestResults/coverage.opencover.xml
           # Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "Kustomization",
     "Kustomize",
     "Swashbuckle"
-  ]
+  ],
+  "yaml.schemaStore.enable": false,
 }

--- a/devops/kustomize/base/database/kustomization.yaml
+++ b/devops/kustomize/base/database/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - statefulset.yaml
+  # - statefulset.yaml
+  - network-policy.yaml

--- a/devops/kustomize/base/database/network-policy.yaml
+++ b/devops/kustomize/base/database/network-policy.yaml
@@ -1,0 +1,88 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: enable-api-to-database
+  labels:
+    name: enable-api-to-database
+    part-of: hsb
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+  annotations:
+    description: Enable the api to communicate with the database
+spec:
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.99.8.2/32
+      ports:
+        - port: 5432
+          protocol: TCP
+
+  podSelector:
+    matchLabels:
+      part-of: hsb
+      component: api
+  policyTypes:
+    - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: enable-db-migration-to-database
+  labels:
+    name: enable-db-migration-to-database
+    part-of: hsb
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+  annotations:
+    description: Enable the db-migration to communicate with the database
+spec:
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.99.8.2/32
+      ports:
+        - port: 5432
+          protocol: TCP
+
+  podSelector:
+    matchLabels:
+      part-of: hsb
+      component: database
+  policyTypes:
+    - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: enable-db-migration-to-internet
+  labels:
+    name: enable-db-migration-to-internet
+    part-of: hsb
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+  annotations:
+    description: Enable the db-migration to communicate with the internet
+spec:
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 142.34.229.249/32
+        - ipBlock:
+            cidr: 142.34.94.249/32
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      part-of: hsb
+      component: database
+  policyTypes:
+    - Egress

--- a/devops/kustomize/base/tekton/imageStreams/api.yaml
+++ b/devops/kustomize/base/tekton/imageStreams/api.yaml
@@ -1,0 +1,28 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: api
+  namespace: e89443-tools
+  labels:
+    component: api
+    created-by: jeremy.foster
+    managed-by: kustomize
+    name: api
+    part-of: hsb
+    version: 1.0.0
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: >-
+          artifacts.developer.gov.bc.ca/github-docker-remote/bcgov/bcgov/hsb-dashboard/api:latest
+      generation: 1
+      importPolicy:
+        scheduled: true
+        importMode: Legacy
+      referencePolicy:
+        type: Source

--- a/devops/kustomize/base/tekton/imageStreams/app.yaml
+++ b/devops/kustomize/base/tekton/imageStreams/app.yaml
@@ -1,0 +1,28 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: dashboard
+  namespace: e89443-tools
+  labels:
+    component: app
+    created-by: jeremy.foster
+    managed-by: kustomize
+    name: dashboard
+    part-of: hsb
+    version: 1.0.0
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: >-
+          artifacts.developer.gov.bc.ca/github-docker-remote/bcgov/bcgov/hsb-dashboard/dashboard:latest
+      generation: 1
+      importPolicy:
+        scheduled: true
+        importMode: Legacy
+      referencePolicy:
+        type: Source

--- a/devops/kustomize/base/tekton/imageStreams/db-migration.yaml
+++ b/devops/kustomize/base/tekton/imageStreams/db-migration.yaml
@@ -1,0 +1,28 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: db-migration
+  namespace: e89443-tools
+  labels:
+    component: db-migration
+    created-by: jeremy.foster
+    managed-by: kustomize
+    name: database
+    part-of: hsb
+    version: 1.0.0
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: >-
+          artifacts.developer.gov.bc.ca/github-docker-remote/bcgov/bcgov/hsb-dashboard/db-migration:latest
+      generation: 1
+      importPolicy:
+        scheduled: true
+        importMode: Legacy
+      referencePolicy:
+        type: Source

--- a/devops/kustomize/base/tekton/roles/role-bind.yaml
+++ b/devops/kustomize/base/tekton/roles/role-bind.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline
+  namespace: e89443-dev
+  labels:
+    name: pipeline
+    part-of: hsb
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+    created-by: jeremy.foster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: e89443-tools

--- a/devops/kustomize/base/tekton/roles/role.yaml
+++ b/devops/kustomize/base/tekton/roles/role.yaml
@@ -1,0 +1,100 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pipeline
+  namespace: e89443-dev
+  labels:
+    name: pipeline
+    part-of: hsb
+    version: 1.0.0
+    component: pipeline
+    managed-by: kustomize
+    created-by: jeremy.foster
+rules:
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - statefulsets/scale
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - configmaps
+      - secrets
+      - pods
+      - pods/attach
+      - pods/exec
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - patch
+      - update
+      - create
+      - list
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - update
+      - patch
+      - watch

--- a/devops/kustomize/base/tekton/taskruns/buildah.yaml
+++ b/devops/kustomize/base/tekton/taskruns/buildah.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: example-buildah-run-
+  # name: example-buildah-run
+  labels:
+    name: db-migration
+    part-of: hsb
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+
+spec:
+  taskRef:
+    kind: Task
+    name: buildah
+
+  params:
+    - name: SOURCE_IMAGE
+      value: api
+    - name: IMAGE
+      value: api

--- a/devops/kustomize/base/tekton/taskruns/db-migration.yaml
+++ b/devops/kustomize/base/tekton/taskruns/db-migration.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: example-db-migration-run-
+  # name: example-db-migration-run
+  labels:
+    name: db-migration
+    part-of: hsb
+    version: 1.0.0
+    component: database
+    managed-by: kustomize
+    created-by: jeremy.foster
+
+spec:
+  taskRef:
+    kind: Task
+    name: db-migration
+
+  params:
+    - name: DEPLOY_TO
+      value: dev
+    - name: MIGRATION
+      value: 0

--- a/devops/kustomize/base/tekton/tasks/buildah.yaml
+++ b/devops/kustomize/base/tekton/tasks/buildah.yaml
@@ -1,0 +1,69 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+  description: |
+    Using Buildah pull images from GitHub registry into Openshift.
+  annotations:
+    tekton.dev/displayName: Buildah Image
+    tekton.dev/pipelines.minVersion: 0.17.0
+    tekton.dev/tags: build
+  labels:
+    name: buildah
+    part-of: hsb
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: SOURCE_IMAGE_REGISTRY
+      description: The Root url of the image registry.
+      default: ghcr.io/bcgov/hsb-dashboard
+    - name: SOURCE_IMAGE
+      description: Name of image to pull.
+    - name: SOURCE_IMAGE_TAG
+      description: The tag of the source image.
+      type: string
+      default: latest
+
+    - name: IMAGE_REGISTRY
+      description: The Root url of the image registry.
+      default: image-registry.apps.emerald.devops.gov.bc.ca/e89443-tools
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+
+    - name: STORAGE_DRIVER
+      description: Set buildah storage driver
+      default: vfs
+  steps:
+    - name: pull
+      image: image-registry.apps.emerald.devops.gov.bc.ca/e89443-tools/buildah:latest
+      env:
+        - name: HTTP_PROXY
+          value: http://swpxkam.gov.bc.ca:8080
+        - name: HTTPS_PROXY
+          value: http://swpxkam.gov.bc.ca:8080
+        - name: NO_PROXY
+          value: .cluster.local,.svc,10.91.0.0/16,172.30.0.0/16,127.0.0.1,localhost,.gov.bc.ca
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+        runAsUser: 0
+      resources:
+        requests:
+          memory: 250Mi
+          cpu: 500m
+        limits:
+          memory: 1Gi
+          cpu: 1000m
+      script: |
+        # Pull the image from the source registry
+        buildah pull $(params.SOURCE_IMAGE_REGISTRY)/$(params.SOURCE_IMAGE):$(params.SOURCE_IMAGE_TAG)
+
+        # Push the image to the registry.
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG)

--- a/devops/kustomize/base/tekton/tasks/db-migration.yaml
+++ b/devops/kustomize/base/tekton/tasks/db-migration.yaml
@@ -1,0 +1,123 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: db-migration
+  description: >-
+    This task runs the database migration.
+  annotations:
+    tekton.dev/displayName: Run Database Migration
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: docker
+  labels:
+    name: db-migration
+    part-of: hsb
+    version: 1.0.0
+    component: task
+    managed-by: kustomize
+spec:
+  params:
+    - name: IMAGE
+      description: The name of the database migration image.
+      type: string
+      default: db-migration
+    - name: PROJECT_SHORTNAME
+      description: The shortname of the project namespace.
+      type: string
+      default: e89443
+
+    - name: IMAGE_REGISTRY
+      description: The image registry
+      type: string
+      default: image-registry.apps.emerald.devops.gov.bc.ca
+    - name: IMAGE_TAG
+      description: The tag given to the built image.
+      type: string
+      default: latest
+
+    - name: DEPLOY_TO
+      description: Which environment to deploy to
+      type: string
+      default: dev
+
+    - name: MIGRATION
+      description: The migration to apply
+      type: string
+
+  steps:
+    - name: run
+      image: "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+      resources: {}
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        echo "Running database migration in $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO)"
+        overrides="{
+            \"apiVersion\":\"v1\",
+            \"spec\":{
+              \"containers\":[
+                {
+                  \"name\":\"$(params.IMAGE)\",
+                  \"image\":\"$IMAGE_REGISTRY/$(params.PROJECT_SHORTNAME)-tools/$(params.IMAGE):$(params.DEPLOY_TO)\",
+                  \"env\":[
+                    {
+                      \"name\":\"MIGRATION\",
+                      \"value\":\"$(params.MIGRATION)\"
+                    },
+                    {
+                      \"name\":\"ConnectionStrings__Default\",
+                      \"valueFrom\":{
+                        \"secretKeyRef\":{
+                          \"name\":\"database\",
+                          \"key\":\"CONNECTION_STRING\"
+                        }
+                      }
+                    },
+                    {
+                      \"name\":\"POSTGRES_USER\",
+                      \"valueFrom\":{
+                        \"secretKeyRef\":{
+                          \"name\":\"database\",
+                          \"key\":\"DB_USER\"
+                        }
+                      }
+                    },
+                    {
+                      \"name\":\"POSTGRES_PASSWORD\",
+                      \"valueFrom\":{
+                        \"secretKeyRef\":{
+                          \"name\":\"database\",
+                          \"key\":\"DB_PASSWORD\"
+                        }
+                      }
+                    }
+                  ],
+                  \"labels\":{
+                    \"name\":\"db-migration\",\"part-of\":\"hsb\",\"component\":\"database\",\"DataClass\":\"Low\"
+                    },
+                  \"resources\":{
+                    \"requests\":{
+                      \"memory\":\"250Mi\",
+                      \"cpu\":\"50m\"
+                    },
+                    \"limits\":{
+                      \"memory\":\"500Mi\",
+                      \"cpu\":\"500m\"
+                    }
+                  },
+                  \"imagePullPolicy\": \"Always\"
+                }
+              ]
+            }
+          }"
+        oc run $(params.IMAGE) \
+          -n $(params.PROJECT_SHORTNAME)-$(params.DEPLOY_TO) \
+          --image=$(params.IMAGE) \
+          --image-pull-policy=Always \
+          --attach \
+          --rm \
+          --labels='name=db-migration,part-of=hsb,component=database,DataClass=Low' \
+          --restart=Never \
+          --timeout=10m \
+          --override-type='merge' \
+          --overrides="$overrides"

--- a/devops/sysdig/Monitoring.md
+++ b/devops/sysdig/Monitoring.md
@@ -8,7 +8,7 @@ We created the Kubernetes CRD template with required information and applied the
 
 For furture team onboarding or any update will be added to `./tno-sysdig-access.yaml` file. Anyone with contributor access to namespace can publish the changes to `*-tools` namespace and it will reflected in sysdig.
 
-```
+```yaml
 apiVersion: ops.gov.bc.ca/v1alpha1
 kind: SysdigTeam
 metadata:
@@ -18,16 +18,12 @@ spec:
   team:
     description: The Sysdig Team for the OpenShift Project Set e89443 - TNO
     users:
-    - name: Jeremy.1.Foster@gov.bc.ca
-      role: ROLE_TEAM_STANDARD
-    - name: cello.liu@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: Carolynn.Hunter@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: kyle.morris@gov.bc.ca
-      role: ROLE_TEAM_READ
-    - name: Bobbi.Bjornholt@gov.bc.ca
-      role: ROLE_TEAM_READ
+      - name: Jeremy.1.Foster@gov.bc.ca
+        role: ROLE_TEAM_EDIT
+      - name: Jeremy.1.Foster@gov.bc.ca
+        role: ROLE_TEAM_STANDARD
+      - name: Jeremy.1.Foster@gov.bc.ca
+        role: ROLE_TEAM_READ
 ```
 
 ## Team Access
@@ -39,13 +35,3 @@ To access them:
 - Navigate to the bottom left hand of the page to switch your team, which should be named as [PROJECT_SET_LICENSE_PLATE]-team.
 
 ![Select Teams Image](./images/my_teams.png 'Select Teams!')
-
-### Access Shared Dashboards
-
-TNO Dev Dashboard
-
-- [e89443-dev - Pod Status & Performance](https://app.sysdigcloud.com/#/dashboards/399487?last=3600&scope=kubernetes.cluster.name%20as%20%22cluster%22%20in%20%3F%28%22silver%22%29%20and%20kubernetes.namespace.name%20as%20%22namespace%22%20in%20%3F%28%22e89443-dev%22%29%20and%20kubernetes.workload.type%20as%20%22type%22%20in%20%3F%20and%20kubernetes.workload.name%20as%20%22workload%22%20in%20%3F%20and%20container.label.io.kubernetes.pod.name%20as%20%22pod%22%20in%20%3F)
-
-- [e89443-dev - Pod Rightsizing & Workload Capacity Optimization](https://app.sysdigcloud.com/#/dashboards/399484?last=1209600&scope=kubernetes.cluster.name%20as%20%22cluster%22%20%3D%20%3F%22silver%22%20and%20kubernetes.namespace.name%20as%20%22namespace%22%20in%20%3F%28%22e89443-dev%22%29%20and%20kubernetes.workload.type%20as%20%22type%22%20in%20%3F%20and%20kubernetes.workload.name%20as%20%22workload%22%20in%20%3F%20and%20kubernetes.pod.name%20as%20%22pod%22%20in%20%3F%20and%20container.label.io.kubernetes.container.name%20as%20%22container%22%20in%20%3F)
-
-- [TNO Container Resource Usage](https://app.sysdigcloud.com/#/dashboards/399771?last=1209600&scope=host.hostName%20in%20%3F%20and%20container.name%20in%20%3F%28%22content-service%22%2C%20%22api%22%2C%20%22editor%22%2C%20%22filecopy-service%22%2C%20%22filemonitor-service%22%2C%20%22elastic%22%2C%20%22image-service%22%2C%20%22indexing-service%22%2C%20%22kafka-broker%22%2C%20%22notification-service%22%2C%20%22nlp-service%22%2C%20%22postgres%22%2C%20%22reporting-service%22%2C%20%22subscriber%22%2C%20%22syndication-service%22%2C%20%22transcription-service%22%2C%20%22alertmanager%22%29%20and%20container.image%20in%20%3F)

--- a/devops/sysdig/tno-sysdig-access.yaml
+++ b/devops/sysdig/tno-sysdig-access.yaml
@@ -7,17 +7,7 @@ spec:
   team:
     description: The Sysdig Team for the OpenShift Project Set e89443 - TNO
     users:
-      - name: ckayfish@gmail.com
-        role: ROLE_TEAM_EDIT
-      - name: curtis.kayfish@gov.bc.ca
-        role: ROLE_TEAM_EDIT
-      - name: jeremy.foster@fosol.ca
-        role: ROLE_TEAM_EDIT
       - name: Jeremy.1.Foster@gov.bc.ca
         role: ROLE_TEAM_EDIT
-      - name: kyle.morris@gov.bc.ca
+      - name: brian.price@gov.bc.ca
         role: ROLE_TEAM_EDIT
-      - name: cello.liu@gov.bc.ca
-        role: ROLE_TEAM_STANDARD
-      - name: Carolynn.Hunter@gov.bc.ca
-        role: ROLE_TEAM_READ

--- a/do
+++ b/do
@@ -30,6 +30,8 @@ elif [ "$action" = "stop" ]; then
   docker_stop
 elif [ "$action" = "down" ]; then
   docker_down
+elif [ "$action" = "restart" ]; then
+  docker_restart $s
 elif [ "$action" = "refresh" ]; then
   docker_refresh $s
 elif [ "$action" = "remove" ]; then

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -47,6 +47,16 @@ docker_remove () {
   docker image rm -f hsb:$1
 }
 
+# Stop, and start the specified docker service.
+docker_restart () {
+  if [ -z "${1-}" ]; then
+    echo "$0: The service name is required"
+    exit 4
+  fi
+  docker_stop $1
+  docker_up $1
+}
+
 # Stop, remove, build and run the specified docker service.
 docker_refresh () {
   if [ -z "${1-}" ]; then

--- a/scripts/oc.sh
+++ b/scripts/oc.sh
@@ -24,28 +24,113 @@ deploy () {
   tag=${2-'latest'}
   env=${3-}
 
+  IMAGE_REGISTRY=${4-'image-registry.apps.emerald.devops.gov.bc.ca'}
+
   # Extract the random characters of the project namespace.
   project=$(oc project --short); project=${project//-[a-z]*/}; echo $project
   # Change the current environment
   oc project $project-tools
   # login
-  docker login -u $(oc whoami) -p $(oc whoami -t) image-registry.apps.emerald.devops.gov.bc.ca/$project-tools
+  docker login -u $(oc whoami) -p $(oc whoami -t) $IMAGE_REGISTRY/$project-tools
 
   if [ "$image" = "api" ]; then
     # buid and deploy api
-    docker build -f src/api/Dockerfile -t image-registry.apps.emerald.devops.gov.bc.ca/$project-tools/api:$tag .
-    docker push image-registry.apps.emerald.devops.gov.bc.ca/$project-tools/api:$tag
+    docker build -f src/api/Dockerfile -t $IMAGE_REGISTRY/$project-tools/$image:$tag .
+    docker push $IMAGE_REGISTRY/$project-tools/$image:$tag
 
     if [ ! -z "$env" ]; then
-      oc tag api:$tag api:$env
+      oc tag $image:$tag $image:$env
     fi
   elif [ "$image" = "app" ]; then
     # buid and deploy app
-    docker build -f src/dashboard/Dockerfile.prod -t image-registry.apps.emerald.devops.gov.bc.ca/$project-tools/dashboard:$tag ./src/dashboard
-    docker push image-registry.apps.emerald.devops.gov.bc.ca/$project-tools/dashboard:$tag
+    image=dashboard
+    docker build -f src/dashboard/Dockerfile.prod -t $IMAGE_REGISTRY/$project-tools/$image:$tag ./src/dashboard
+    docker push $IMAGE_REGISTRY/$project-tools/$image:$tag
 
     if [ ! -z "$env" ]; then
-      oc tag dashboard:$tag dashboard:$env
+      oc tag $image:$tag $image:$env
+    fi
+  elif [ "$image" = "db" ]; then
+    # buid and deploy app
+    image=db-migration
+    docker build -f src/libs/Dockerfile -t $IMAGE_REGISTRY/$project-tools/$image:$tag ./src/libs
+    docker push $IMAGE_REGISTRY/$project-tools/$image:$tag
+    migration=${4-}
+
+        # --rm \
+    if [ ! -z "$env" ]; then
+      oc tag $image:$tag $image:$env
+      echo "Running database migration in $project-$env"
+      overrides="{
+          \"apiVersion\":\"v1\",
+          \"spec\":{
+            \"containers\":[
+              {
+                \"name\":\"$image\",
+                \"image\":\"$IMAGE_REGISTRY/$project-tools/$image:$env\",
+                \"env\":[
+                  {
+                    \"name\":\"MIGRATION\",
+                    \"value\":\"$migration\"
+                  },
+                  {
+                    \"name\":\"ConnectionStrings__Default\",
+                    \"valueFrom\":{
+                      \"secretKeyRef\":{
+                        \"name\":\"database\",
+                        \"key\":\"CONNECTION_STRING\"
+                      }
+                    }
+                  },
+                  {
+                    \"name\":\"POSTGRES_USER\",
+                    \"valueFrom\":{
+                      \"secretKeyRef\":{
+                        \"name\":\"database\",
+                        \"key\":\"DB_USER\"
+                      }
+                    }
+                  },
+                  {
+                    \"name\":\"POSTGRES_PASSWORD\",
+                    \"valueFrom\":{
+                      \"secretKeyRef\":{
+                        \"name\":\"database\",
+                        \"key\":\"DB_PASSWORD\"
+                      }
+                    }
+                  }
+                ],
+                \"labels\":{
+                  \"name\":\"db-migration\",\"part-of\":\"hsb\",\"component\":\"database\",\"DataClass\":\"Low\"
+                  },
+                \"resources\":{
+                  \"requests\":{
+                    \"memory\":\"250Mi\",
+                    \"cpu\":\"50m\"
+                  },
+                  \"limits\":{
+                    \"memory\":\"500Mi\",
+                    \"cpu\":\"250m\"
+                  }
+                },
+                \"imagePullPolicy\": \"Always\"
+              }
+            ]
+          }
+        }"
+      oc run $image \
+        -n $project-$env \
+        --image=$image \
+        --image-pull-policy=Always \
+        --attach \
+        --rm \
+        --labels='name=db-migration,part-of=hsb,component=database,DataClass=Low' \
+        --restart=Never \
+        --timeout=10m \
+        --override-type='merge' \
+        --overrides="$overrides"
     fi
   fi
 }
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -188,7 +188,7 @@ KEYCLOAK_END_SESSION_PATH=/protocol/openid-connect/logout
 
 NEXTAUTH_URL=http://localhost:$portAppHttp
 NEXTAUTH_SECRET=$privateKey
-" >> ./src/dashboard/.env
+NEXT_WEBPACK_USEPOLLING=false" >> ./src/dashboard/.env
     echo "./src/dashboard/.env created"
   fi
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,21 @@
+IMAGE_REGISTRY='image-registry.apps.emerald.devops.gov.bc.ca'
+
+# Extract the random characters of the project namespace.
+project=$(oc project --short); project=${project//-[a-z]*/}; echo $project
+image=db-migration
+tag=latest
+
+# docker pull $IMAGE_REGISTRY/$project-tools/$image:$tag
+
+docker run $IMAGE_REGISTRY/$project-tools/$image:$tag
+
+# docker rmi --force $IMAGE_REGISTRY/$project-tools/$image:$tag
+# docker build -f src/libs/Dockerfile -t $IMAGE_REGISTRY/$project-tools/$image:$tag ./src/libs --no-cache
+
+# oc project $project-tools
+# docker login -u $(oc whoami) -p $(oc whoami -t) $IMAGE_REGISTRY/$project-tools
+
+# docker push $IMAGE_REGISTRY/$project-tools/$image:$tag
+
+
+# docker tag $IMAGE_REGISTRY/$project-tools/$image:$tag $IMAGE_REGISTRY/$project-tools/$image-2:$tag

--- a/src/libs/.dockerignore
+++ b/src/libs/.dockerignore
@@ -1,5 +1,5 @@
 .vs/
-.env
+**/*.env
 
 # Build results
 [Dd]ebug/

--- a/src/libs/Dockerfile
+++ b/src/libs/Dockerfile
@@ -26,5 +26,5 @@ RUN chmod -R 0777 /.local
 # Run container by default as user with id 1001 (default)
 USER 1001
 
-ENTRYPOINT cd /src/dal && dotnet ef database update -v
+ENTRYPOINT cd /src/dal && dotnet ef database update $MIGRATION -v
 # ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
I was hoping to have automated pipelines, however it doesn't appear Emerald cluster supports this easily.  I've instead created local scripts that automate the build/deploy for the various components.

- Emerald cluster does not allow external ingess, which means webhooks and GitHub Actions cannot interact with Openshift
- I was unable to figure out how to push images to Artifactory image registry directly, however I was able to figure out how to push the bcgov GitHub image registry
- Openshift ImageStreams can be setup with a 15 minute schedule where they check if an image has been updated in Artifactory, or GitHub.
- With schedule ImageStreams it will update the API or APP automatically when new images are push up
- However, current it isn't possible to start a DB migration automatically.  To do this a local script has been created to build and deploy the DB migration.
- I attempted to create a Tekton Task to perform the DB migration, however I have not figured out the necessary NetworkPolicy or Role that will enable this.

## Summary

1. GitHub Actions will now build and push images to the BCGov GitHub image registry.
2. OpenShift ImageStream are scheduled to check every 15 minutes for new images
3. If a new image is detected it will automatically deploy the API or App.
4. Local script `./do deploy db latest dev` will build and deploy the `db-migration` image to update the database