### PR TITLE
HOSTSD-201 Add total storage chart

### DIFF
--- a/src/dashboard/src/components/charts/doughnut/IDoughnutStats.ts
+++ b/src/dashboard/src/components/charts/doughnut/IDoughnutStats.ts
@@ -4,5 +4,7 @@ export interface IDoughnutStats {
   space: string;
   used: string;
   available: string;
+  usedPercent: number;
+  availablePercent: number;
   chart: ChartData<'doughnut', number[], string>;
 }

--- a/src/dashboard/src/components/charts/doughnut/allOrganizations/AllOrganizations.tsx
+++ b/src/dashboard/src/components/charts/doughnut/allOrganizations/AllOrganizations.tsx
@@ -3,17 +3,17 @@
 import styles from './AllOrganizations.module.scss';
 
 import { Button } from '@/components/buttons';
-import { useServerItemsDoughnutChart } from '@/components/charts/hooks/useServerItemsDoughnutChart';
 import { useDashboard } from '@/store';
 import { ArcElement, Chart as ChartJS, Tooltip } from 'chart.js';
 import React from 'react';
 import { Doughnut } from 'react-chartjs-2';
+import { useAllOrganizationsDoughnutChart } from './hooks';
 
 ChartJS.register(ArcElement, Tooltip);
 
 export const AllOrganizations: React.FC = () => {
   const organizations = useDashboard((state) => state.organizations);
-  const data = useServerItemsDoughnutChart();
+  const data = useAllOrganizationsDoughnutChart();
 
   return (
     <div className={styles.panel}>

--- a/src/dashboard/src/components/charts/doughnut/allOrganizations/defaultData.ts
+++ b/src/dashboard/src/components/charts/doughnut/allOrganizations/defaultData.ts
@@ -1,10 +1,12 @@
-import { IDoughnutStats } from './IDoughnutStats';
+import { IDoughnutStats } from '@/components';
 
 // Data for the Donut Chart with specified colors
 export const defaultData: IDoughnutStats = {
   space: '0 TB',
   used: '0 TB',
+  usedPercent: 0,
   available: '0 TB',
+  availablePercent: 0,
   chart: {
     labels: ['Unused', 'Used', 'Allocated'], // Labels to match ring order
     datasets: [

--- a/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/generateDoughnutChart.ts
+++ b/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/generateDoughnutChart.ts
@@ -1,0 +1,44 @@
+import { convertToStorageSize } from '@/utils';
+import { IDoughnutStats } from '../..';
+
+export const generateDoughnutChart = (
+  space: number | undefined = 0,
+  available: number | undefined = 0,
+  data: IDoughnutStats,
+) => {
+  const used = space - available;
+  const usedPercent = space ? (used / space) * 100 : 0;
+  const availablePercent = space ? (available / space) * 100 : 0;
+  const usedCir = usedPercent ? (360 * usedPercent) / 100 : 0;
+  const availableCir = availablePercent ? (360 * availablePercent) / 100 : 0;
+
+  return {
+    space: convertToStorageSize<string>(space, 'MB', 'TB', {
+      formula: Math.trunc,
+    }),
+    used: convertToStorageSize<string>(used, 'MB', 'TB', {
+      formula: Math.trunc,
+    }),
+    available: convertToStorageSize<string>(available, 'MB', 'TB', {
+      formula: Math.trunc,
+    }),
+    usedPercent,
+    availablePercent,
+    chart: {
+      ...data.chart,
+      datasets: [
+        {
+          ...data.chart.datasets[0],
+          data: [availablePercent, 0, 0],
+          circumference: availableCir,
+        },
+        {
+          ...data.chart.datasets[1],
+          data: [usedPercent, 0, 0],
+          circumference: usedCir,
+        },
+        { ...data.chart.datasets[2], data: [100, 0, 0] },
+      ],
+    },
+  };
+};

--- a/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/index.ts
+++ b/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useAllOrganizationsDoughnutChart';

--- a/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/useAllOrganizationsDoughnutChart.ts
+++ b/src/dashboard/src/components/charts/doughnut/allOrganizations/hooks/useAllOrganizationsDoughnutChart.ts
@@ -1,10 +1,10 @@
 import { useDashboard } from '@/store';
 import React from 'react';
-import { IDoughnutStats } from '../doughnut/allOrganizations/IDoughnutStats';
-import { defaultData } from '../doughnut/allOrganizations/defaultData';
+import { IDoughnutStats } from '../..';
+import { defaultData } from '../defaultData';
 import { generateDoughnutChart } from './generateDoughnutChart';
 
-export const useServerItemsDoughnutChart = () => {
+export const useAllOrganizationsDoughnutChart = () => {
   const serverItems = useDashboard((state) => state.serverItems);
 
   const [data, setData] = React.useState<IDoughnutStats>(defaultData);

--- a/src/dashboard/src/components/charts/doughnut/index.ts
+++ b/src/dashboard/src/components/charts/doughnut/index.ts
@@ -1,2 +1,3 @@
+export * from './IDoughnutStats';
 export * from './allOrganizations';
 export * from './totalStorage';

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/TotalStorage.tsx
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/TotalStorage.tsx
@@ -1,15 +1,16 @@
 'use client';
 
+import { convertToStorageSize } from '@/utils';
 import { ArcElement, Chart as ChartJS, Tooltip } from 'chart.js';
 import React from 'react';
 import { Doughnut } from 'react-chartjs-2';
 import styles from './TotalStorage.module.scss';
-import { defaultData } from './defaultData';
+import { useTotalStorageDoughnutChart } from './hooks';
 
 ChartJS.register(ArcElement, Tooltip);
 
 export const TotalStorage: React.FC = () => {
-  const data = defaultData;
+  const data = useTotalStorageDoughnutChart();
 
   return (
     <div className={styles.panel}>
@@ -17,7 +18,7 @@ export const TotalStorage: React.FC = () => {
       <div className={styles.chartContainer}>
         <div className={styles.chart}>
           <Doughnut
-            data={data}
+            data={data.chart}
             options={{
               rotation: 180,
               circumference: 360,
@@ -30,9 +31,9 @@ export const TotalStorage: React.FC = () => {
                   callbacks: {
                     label: function (context: { dataIndex: any; parsed: any }) {
                       let labelIndex = context.dataIndex;
-                      let label = data.labels[labelIndex] || '';
+                      let label = data.chart.labels?.[labelIndex] || '';
                       let value = context.parsed;
-                      return `${label}: ${value}GB`;
+                      return `${label}: ${convertToStorageSize(value, 'MB', 'TB')}`;
                     },
                     title: function () {
                       return ''; // Return an empty string to remove the title for tooltips
@@ -44,12 +45,12 @@ export const TotalStorage: React.FC = () => {
           />
         </div>
         <p className={styles.percentage}>
-          <span>{data.percentage.toFixed(0)}%</span>Used
+          <span>{data.usedPercent.toFixed(2)}%</span>Used
         </p>
-        <p className={styles.total}>Total: {data.space}GB</p>
+        <p className={styles.total}>Total: {data.space}</p>
         <div className={styles.footer}>
-          <p>Used: {data.used}GB</p>
-          <p>Unused: {data.available}GB</p>
+          <p>Used: {data.used.replace(' ', '')}</p>
+          <p>Unused: {data.available.replace(' ', '')}</p>
         </div>
       </div>
     </div>

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/defaultData.ts
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/defaultData.ts
@@ -1,21 +1,20 @@
-  const totalSpaceGB = 100;
-  const usedSpaceGB = 75;
-  const availableSpaceGB = totalSpaceGB - usedSpaceGB;
-  const usedPercentage = (usedSpaceGB / totalSpaceGB) * 100;
+import { IDoughnutStats } from '@/components/charts';
 
-  export const defaultData = {
-    space: totalSpaceGB,
-    used: usedSpaceGB,
-    available: availableSpaceGB,
-    percentage: usedPercentage,
-
+export const defaultData: IDoughnutStats = {
+  space: '0 GB',
+  used: '0 GB',
+  usedPercent: 0,
+  available: '0 GB',
+  availablePercent: 0,
+  chart: {
     labels: ['Used', 'Unused'],
     datasets: [
       {
-        data: [usedSpaceGB, availableSpaceGB], // Data for 'Used' and 'Unused'
+        data: [0, 0], // Data for 'Used' and 'Unused'
         backgroundColor: ['#DF9901', '#FFECC2'], // Colors for 'Used' and 'Unused'
         borderColor: ['#DF9901', '#FFECC2'], // Border colors for 'Used' and 'Unused'
         borderWidth: 1,
-      }
-    ]
-  };
+      },
+    ],
+  },
+};

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/generateDoughnutChart.ts
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/generateDoughnutChart.ts
@@ -1,5 +1,5 @@
 import { convertToStorageSize } from '@/utils';
-import { IDoughnutStats } from '../doughnut/allOrganizations/IDoughnutStats';
+import { IDoughnutStats } from '../..';
 
 export const generateDoughnutChart = (
   space: number | undefined = 0,
@@ -9,8 +9,6 @@ export const generateDoughnutChart = (
   const used = space - available;
   const usedPercent = space ? (used / space) * 100 : 0;
   const availablePercent = space ? (available / space) * 100 : 0;
-  const usedCir = usedPercent ? (360 * usedPercent) / 100 : 0;
-  const availableCir = availablePercent ? (360 * availablePercent) / 100 : 0;
 
   return {
     space: convertToStorageSize<string>(space, 'MB', 'TB', {
@@ -22,20 +20,15 @@ export const generateDoughnutChart = (
     available: convertToStorageSize<string>(available, 'MB', 'TB', {
       formula: Math.trunc,
     }),
+    usedPercent,
+    availablePercent,
     chart: {
       ...data.chart,
       datasets: [
         {
           ...data.chart.datasets[0],
-          data: [availablePercent, 0, 0],
-          circumference: availableCir,
+          data: [used, available],
         },
-        {
-          ...data.chart.datasets[1],
-          data: [usedPercent, 0, 0],
-          circumference: usedCir,
-        },
-        { ...data.chart.datasets[2], data: [100, 0, 0] },
       ],
     },
   };

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/index.ts
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useTotalStorageDoughnutChart';

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/useTotalStorageDoughnutChart.ts
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/hooks/useTotalStorageDoughnutChart.ts
@@ -1,0 +1,25 @@
+import { useDashboard } from '@/store';
+import React from 'react';
+import { IDoughnutStats } from '../..';
+import { defaultData } from '../defaultData';
+import { generateDoughnutChart } from './generateDoughnutChart';
+
+export const useTotalStorageDoughnutChart = () => {
+  const serverItems = useDashboard((state) => state.serverItems);
+
+  const [data, setData] = React.useState<IDoughnutStats>(defaultData);
+
+  React.useEffect(() => {
+    if (serverItems.length) {
+      const space = serverItems.map((si) => si.capacity!).reduce((a, b) => (a ?? 0) + (b ?? 0));
+      const available = serverItems
+        .map((si) => si.availableSpace!)
+        .reduce((a, b) => (a ?? 0) + (b ?? 0));
+      setData((data) => generateDoughnutChart(space, available, data));
+    } else {
+      setData(defaultData);
+    }
+  }, [serverItems]);
+
+  return data;
+};

--- a/src/dashboard/src/components/charts/hooks/index.ts
+++ b/src/dashboard/src/components/charts/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useServerItemsDoughnutChart';

--- a/src/dashboard/src/components/charts/index.ts
+++ b/src/dashboard/src/components/charts/index.ts
@@ -1,6 +1,5 @@
 export * from './bar';
 export * from './doughnut';
-export * from './hooks';
 export * from './line';
 export * from './smallBar';
 export * from './storageTrends';


### PR DESCRIPTION
Hooked up the Total Storage Allocation doughnut chart.  This chart uses the dashboard state store.

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/4a48b988-9da6-4537-9784-a26ece3cf9ea)
