### PR TITLE
Rollback dependency version

### DIFF
--- a/src/libs/core/HSB.Core.csproj
+++ b/src/libs/core/HSB.Core.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cannot upgrade `System.IdentityModel.Tokens.Jwt` to 7 presently, despite the security alert.