### PR TITLE
HOSTSD-229 Client pages

### DIFF
--- a/src/dashboard/src/app/client/servers/page.tsx
+++ b/src/dashboard/src/app/client/servers/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AllocationByStorageVolume, Col } from '@/components';
+import { AllocationTable, Col } from '@/components';
 import { useSecureRoute } from '@/hooks';
 import { useFilteredOrganizations, useFilteredServerItems } from '@/hooks/filter';
 
@@ -12,8 +12,8 @@ export default function Page() {
 
   return (
     <Col>
-      <h1></h1>All Servers
-      <AllocationByStorageVolume organizations={organizations} serverItems={serverItems} />
+      <h1>All Servers</h1>
+      <AllocationTable operatingSystem={''} serverItems={serverItems} />
     </Col>
   );
 }

--- a/src/dashboard/src/components/charts/allocationTable/AllocationTable.module.scss
+++ b/src/dashboard/src/components/charts/allocationTable/AllocationTable.module.scss
@@ -215,3 +215,7 @@
         }
     }
 }
+
+.link {
+  cursor: pointer;
+}

--- a/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
+++ b/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
@@ -18,19 +18,21 @@ export interface IAllocationTableProps {
   operatingSystem?: string;
   serverItems: IServerItemModel[];
   loading?: boolean;
+  onClick?: (serverItem?: IServerItemModel) => void;
 }
 
 export const AllocationTable = ({
   operatingSystem,
   serverItems,
   loading,
+  onClick,
 }: IAllocationTableProps) => {
   const getServerItems = useAllocationByOS(operatingSystem);
 
   const [keyword, setKeyword] = React.useState('');
   const [filter, setFilter] = React.useState(keyword);
   const [sort, setSort] = React.useState<string>('server:asc');
-  const [rows, setRows] = React.useState<ITableRowData[]>([]);
+  const [rows, setRows] = React.useState<ITableRowData<IServerItemModel>[]>([]);
 
   React.useEffect(() => {
     const sorting = sort.split(':');
@@ -43,7 +45,7 @@ export const AllocationTable = ({
           : '[NO NAME]'.toLocaleLowerCase().includes(filter.toLocaleLowerCase())) ||
         (!!si.operatingSystemItem &&
           si.operatingSystemItem.name.toLocaleLowerCase().includes(filter.toLocaleLowerCase())),
-      sorting[0] as keyof ITableRowData,
+      sorting[0] as keyof ITableRowData<IServerItemModel>,
       sorting[1] as any,
     );
     setRows(rows);
@@ -90,15 +92,16 @@ export const AllocationTable = ({
           <p>Total</p>
         </div>
         <div className={styles.chart}>
-          {rows.map((data, index) => (
+          {rows.map((row, index) => (
             <TableRow
               key={index}
-              server={data.server}
-              tenant={data.tenant}
-              os={data.os}
-              capacity={data.capacity}
-              available={data.available}
+              server={row.server}
+              tenant={row.tenant}
+              os={row.os}
+              capacity={row.capacity}
+              available={row.available}
               showTenant={showTenants}
+              onClick={() => onClick?.(row.data)}
             />
           ))}
         </div>

--- a/src/dashboard/src/components/charts/allocationTable/ITableRowData.ts
+++ b/src/dashboard/src/components/charts/allocationTable/ITableRowData.ts
@@ -1,7 +1,8 @@
-export interface ITableRowData {
+export interface ITableRowData<T> {
   server: string;
   tenant: string;
   os: string;
   capacity: number;
   available: number;
+  data?: T;
 }

--- a/src/dashboard/src/components/charts/allocationTable/TableRow.tsx
+++ b/src/dashboard/src/components/charts/allocationTable/TableRow.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import React from 'react';
 import { convertToStorageSize } from './../../../utils/convertToStorageSize';
 import styles from './AllocationTable.module.scss';
@@ -10,6 +9,7 @@ interface TableRowProps {
   capacity: number;
   available: number;
   showTenant?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLLabelElement, MouseEvent>) => void;
 }
 
 export const TableRow: React.FC<TableRowProps> = ({
@@ -19,6 +19,7 @@ export const TableRow: React.FC<TableRowProps> = ({
   capacity,
   available,
   showTenant,
+  onClick,
 }) => {
   const percentageUsed = capacity ? Math.round(((capacity - available) / capacity) * 100) : 0;
   const capacityValue = convertToStorageSize<string>(capacity, 'MB', 'TB');
@@ -27,9 +28,15 @@ export const TableRow: React.FC<TableRowProps> = ({
   return (
     <div className={styles.row}>
       <div className={styles.info}>
-        <Link href={``} title={server}>
-          {server}
-        </Link>
+        <p>
+          {onClick ? (
+            <label className={styles.link} onClick={(e) => onClick?.(e)}>
+              {server}
+            </label>
+          ) : (
+            <label>{server}</label>
+          )}
+        </p>
         {showTenant ? <p title={tenant}>{tenant}</p> : ''}
         <p title={os}>{os}</p>
         <p title={capacityValue}>{capacityValue}</p>

--- a/src/dashboard/src/components/charts/allocationTable/defaultData.ts
+++ b/src/dashboard/src/components/charts/allocationTable/defaultData.ts
@@ -1,6 +1,7 @@
+import { IServerItemModel } from '@/hooks';
 import { ITableRowData } from './ITableRowData';
 
-export const tableRowData: ITableRowData[] = [
+export const tableRowData: ITableRowData<IServerItemModel>[] = [
   {
     server: 'Server Alpha',
     tenant: '',

--- a/src/dashboard/src/components/charts/allocationTable/hooks/useAllocationByOS.ts
+++ b/src/dashboard/src/components/charts/allocationTable/hooks/useAllocationByOS.ts
@@ -16,7 +16,7 @@ export const useAllocationByOS = (operatingSystem?: string) => {
     (
       serverItems: IServerItemModel[],
       filter: (serverItem: IServerItemModel) => boolean = () => true,
-      sort: keyof ITableRowData = 'server',
+      sort: keyof ITableRowData<IServerItemModel> = 'server',
       direction: 'asc' | 'desc' = 'asc',
     ) => {
       const data = serverItems
@@ -29,13 +29,14 @@ export const useAllocationByOS = (operatingSystem?: string) => {
           const className = si.operatingSystemItem?.rawData.u_class;
           return (!operatingSystem || className === operatingSystem) && filter(si);
         })
-        .map<ITableRowData>((si) => {
+        .map<ITableRowData<IServerItemModel>>((si) => {
           return {
             server: si.name.length ? si.name : '[NO NAME]',
             os: si.operatingSystemItem?.name ?? '',
             tenant: si.tenant?.name ?? '',
             capacity: si.capacity ?? 0,
             available: si.availableSpace ?? 0,
+            data: si,
           };
         })
         .sort((a, b) => {

--- a/src/dashboard/src/components/charts/bar/allocationByOS/AllocationByOS.tsx
+++ b/src/dashboard/src/components/charts/bar/allocationByOS/AllocationByOS.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { IOperatingSystemItemModel, IServerItemModel } from '@/hooks';
-import Link from 'next/link';
 import { BarRow, SmallBarChart } from '../smallBar';
+import styles from '../smallBar/SmallBarChart.module.scss';
 import defaultData from './defaultData';
 import { groupByOS } from './utils';
 
@@ -10,12 +10,14 @@ export interface IAllocationByOSProps {
   serverItems: IServerItemModel[];
   operatingSystemItems: IOperatingSystemItemModel[];
   loading?: boolean;
+  onClick?: (operatingSystemItem?: IOperatingSystemItemModel) => void;
 }
 
 export const AllocationByOS = ({
   serverItems,
   operatingSystemItems,
   loading,
+  onClick,
 }: IAllocationByOSProps) => {
   return (
     <SmallBarChart
@@ -28,7 +30,17 @@ export const AllocationByOS = ({
         return data.datasets.map((os) => (
           <BarRow
             key={os.key}
-            label={<Link href="">{os.label}</Link>}
+            label={
+              <p>
+                {onClick && os.data ? (
+                  <label className={styles.link} onClick={() => onClick?.(os.data)}>
+                    {os.label}
+                  </label>
+                ) : (
+                  <p>{os.label}</p>
+                )}
+              </p>
+            }
             capacity={os.capacity}
             available={os.available}
           />

--- a/src/dashboard/src/components/charts/bar/allocationByOS/defaultData.ts
+++ b/src/dashboard/src/components/charts/bar/allocationByOS/defaultData.ts
@@ -1,7 +1,8 @@
+import { IOperatingSystemItemModel } from '@/hooks';
 import { IBarChartData } from '../smallBar/IBarChartData';
 import { IBarChartRowData } from '../smallBar/IBarChartRowData';
 
-const defaultData: IBarChartData<IBarChartRowData> = {
+const defaultData: IBarChartData<IBarChartRowData<IOperatingSystemItemModel>> = {
   labels: ['Operating System', 'Allocated', 'Used', 'Unused', 'Percentage Used'],
   datasets: [
     {

--- a/src/dashboard/src/components/charts/bar/allocationByOS/utils/groupByOS.ts
+++ b/src/dashboard/src/components/charts/bar/allocationByOS/utils/groupByOS.ts
@@ -6,7 +6,7 @@ export const groupByOS = (
   serverItems: IServerItemModel[],
   operatingSystemItems: IOperatingSystemItemModel[],
 ) => {
-  const groups = groupBy<IServerItemModel, IBarChartRowData>(
+  const groups = groupBy<IServerItemModel, any>(
     serverItems,
     (item) => `${item.operatingSystemItemId ?? 'NA'}`,
     (item) => {
@@ -20,14 +20,15 @@ export const groupByOS = (
   );
 
   const result = Object.keys(groups)
-    .map<IBarChartRowData>((key) => {
+    .map<IBarChartRowData<IOperatingSystemItemModel | undefined>>((key) => {
       const items = groups[key];
       const capacity = items.reduce((result, item) => result + item.capacity, 0);
       const available = items.reduce((result, item) => result + item.available, 0);
       const label =
         key === 'NA' ? 'NA' : operatingSystemItems.find((os) => os.id === +key)?.name ?? 'NA';
+      const os = operatingSystemItems.find((os) => os.id == +key);
 
-      return { key, label, capacity, available };
+      return { key, label, capacity, available, data: os };
     })
     .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
 

--- a/src/dashboard/src/components/charts/bar/allocationByStorageVolume/AllocationByStorageVolume.module.scss
+++ b/src/dashboard/src/components/charts/bar/allocationByStorageVolume/AllocationByStorageVolume.module.scss
@@ -1,181 +1,185 @@
 @import '@/styles/utils.scss';
 
 .panel {
-    @include panel-style(560px, 560px, unset, 1310px);
+  @include panel-style(560px, 560px, unset, 1310px);
 
-    >button {
-        @include export-btn;
-    }
+  >button {
+    @include export-btn;
+  }
 }
 
 .sort {
-    display: flex;
-    align-items: center;
-    margin: 15px 0;
+  display: flex;
+  align-items: center;
+  margin: 15px 0;
 
-    select {
-        min-width: 233px;
-    }
+  select {
+    min-width: 233px;
+  }
 
-    input {
-        margin-left: 18px;
-    }
+  input {
+    margin-left: 18px;
+  }
 }
 
 .chartContainer {
-    max-height: 345px;
-    overflow-y: scroll;
-    padding-right: 8px;
-    scrollbar-width: thin;
-    scrollbar-color: $chart-gray $light-gray;
+  max-height: 345px;
+  overflow-y: scroll;
+  padding-right: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: $chart-gray $light-gray;
 
-    @include scrollBar;
+  @include scrollBar;
 }
 
 .barChart {
-    position: relative;
-    padding: 5px 0 12px;
+  position: relative;
+  padding: 5px 0 12px;
+
+  &:hover {
+    background-color: $light-gray;
+  }
+
+  a {
+    color: $bc-black;
+    font-weight: bold;
+    text-decoration: underline;
+    margin-left: 5px;
 
     &:hover {
-        background-color: $light-gray;
+      opacity: 0.8;
     }
+  }
 
-    a {
-        color: $bc-black;
-        font-weight: bold;
-        text-decoration: underline;
-        margin-left: 5px;
-
-        &:hover {
-            opacity: 0.8;
-        }
-    }
-
-    p {
-        position: absolute;
-        right: 8px;
-        top: 10px;
-        font-size: $font-size-12;
-        color: $info-gray;
-    }
+  p {
+    position: absolute;
+    right: 8px;
+    top: 10px;
+    font-size: $font-size-12;
+    color: $info-gray;
+  }
 }
 
 .barLine {
-    height: 18px;
-    width: 100%;
-    background-color: $chart-gray;
-    border-radius: 10px;
-    margin-top: 12px;
+  height: 18px;
+  width: 100%;
+  background-color: $chart-gray;
+  border-radius: 10px;
+  margin-top: 12px;
 
-    &:hover {
-        background-color: $dark-gray;
-        transition: background-color, .4s;
+  &:hover {
+    background-color: $dark-gray;
+    transition: background-color, .4s;
 
-        .percentage {
-            background-color: $bc-blue;
-            transition: background-color, .4s;
+    .percentage {
+      background-color: $bc-blue;
+      transition: background-color, .4s;
 
-            .tooltip {
-                opacity: .85;
-                transition: opacity, .4s;
-            }
-        }
+      .tooltip {
+        opacity: .85;
+        transition: opacity, .4s;
+      }
     }
+  }
 }
 
 .percentage {
-    height: 100%;
-    width: 50%;
-    background-color: $chart-blue;
-    border-radius: 10px;
-    position: relative;
+  height: 100%;
+  width: 50%;
+  background-color: $chart-blue;
+  border-radius: 10px;
+  position: relative;
 }
 
 .tooltip {
-    opacity: 0;
-    background-color: $bc-black;
-    height: 25px;
-    width: 100px;
+  opacity: 0;
+  background-color: $bc-black;
+  height: 25px;
+  width: 100px;
+  position: absolute;
+  top: -30px;
+  right: 0;
+  border-radius: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+
+  &::after {
+    content: "";
+    height: 8px;
+    width: 8px;
+    display: inline-block;
+    background-color: #313132;
+    transform: rotate(135deg);
     position: absolute;
-    top: -30px;
-    right: 0;
-    border-radius: 6px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1;
+    bottom: -4px;
+  }
 
-    &::after {
-        content: "";
-        height: 8px;
-        width: 8px;
-        display: inline-block;
-        background-color: #313132;
-        transform: rotate(135deg);
-        position: absolute;
-        bottom: -4px;
-    }
-
-    p {
-        color: $white;
-        position: unset;
-    }
+  p {
+    color: $white;
+    position: unset;
+  }
 }
 
 .footer {
+  display: flex;
+  position: absolute;
+  bottom: 28px;
+  left: 0;
+  padding-left: 22px;
+  background-color: $white;
+  width: 100%;
+
+  p {
     display: flex;
-    position: absolute;
-    bottom: 28px;
-    left: 0;
-    padding-left: 22px;
-    background-color: $white;
-    width: 100%;
+    margin-right: 35px;
 
-    p {
-        display: flex;
-        margin-right: 35px;
-
-        &::before {
-            content: '';
-            display: inline-block;
-            height: 22px;
-            width: 22px;
-            background-color: $chart-blue;
-            border-radius: 50%;
-            margin-right: 15px;
-        }
-
-        &:last-child::before {
-            background-color: $chart-gray;
-        }
+    &::before {
+      content: '';
+      display: inline-block;
+      height: 22px;
+      width: 22px;
+      background-color: $chart-blue;
+      border-radius: 50%;
+      margin-right: 15px;
     }
+
+    &:last-child::before {
+      background-color: $chart-gray;
+    }
+  }
 }
 
 .linesContainer {
-    height: 100%;
-    max-height: 380px;
-    position: absolute;
-    width: 100%;
-    max-width: calc(100% - 57px);
+  height: 100%;
+  max-height: 380px;
+  position: absolute;
+  width: 100%;
+  max-width: calc(100% - 57px);
 }
 
 .percentageLine {
-    position: absolute;
-    bottom: 0;
-    height: 100%;
-    
-    .line {
-      width: 1px;
-      height: 92%;
-      background-color: $light-gray;
-    }
-    
-    .label {
-      position: absolute;
-      bottom: 5px;
-      left: 5px;
-      transform: translateX(-50%);
-      font-size: $font-size-small;
-      color: $info-gray;
-    }
+  position: absolute;
+  bottom: 0;
+  height: 100%;
+
+  .line {
+    width: 1px;
+    height: 92%;
+    background-color: $light-gray;
   }
+
+  .label {
+    position: absolute;
+    bottom: 5px;
+    left: 5px;
+    transform: translateX(-50%);
+    font-size: $font-size-small;
+    color: $info-gray;
+  }
+}
+
+.link {
+  cursor: pointer;
+}

--- a/src/dashboard/src/components/charts/bar/allocationByStorageVolume/AllocationByStorageVolume.tsx
+++ b/src/dashboard/src/components/charts/bar/allocationByStorageVolume/AllocationByStorageVolume.tsx
@@ -16,12 +16,14 @@ export interface IAllocationByStorageVolumeProps {
   organizations: IOrganizationModel[];
   serverItems: IServerItemModel[];
   loading?: boolean;
+  onClick?: (organization: IOrganizationModel) => void;
 }
 
 export const AllocationByStorageVolume = ({
   organizations,
   serverItems,
   loading,
+  onClick,
 }: IAllocationByStorageVolumeProps) => {
   const [sortOption, setSortOption] = React.useState<number>(0);
   const [search, setSearch] = React.useState('');
@@ -87,10 +89,10 @@ export const AllocationByStorageVolume = ({
           return (
             <BarChart
               key={org.id}
-              to={`/hsb/dashboard/${org.id}`}
               label={org.name}
               availableSpace={org.availableSpace}
               totalStorage={org.capacity}
+              onClick={() => onClick?.(org)}
             />
           );
         })}

--- a/src/dashboard/src/components/charts/bar/allocationByStorageVolume/BarChart.tsx
+++ b/src/dashboard/src/components/charts/bar/allocationByStorageVolume/BarChart.tsx
@@ -7,9 +7,16 @@ export interface IBarChartProps {
   to?: string;
   availableSpace: number;
   totalStorage: number;
+  onClick?: (e: React.MouseEvent<HTMLLabelElement, MouseEvent>) => void;
 }
 
-export const BarChart: React.FC<IBarChartProps> = ({ label, to, availableSpace, totalStorage }) => {
+export const BarChart: React.FC<IBarChartProps> = ({
+  label,
+  to = '',
+  availableSpace,
+  totalStorage,
+  onClick,
+}) => {
   var validPercentage = totalStorage
     ? Math.min(100, Math.max(0, Math.round(((totalStorage - availableSpace) / totalStorage) * 100)))
     : 0;
@@ -23,7 +30,15 @@ export const BarChart: React.FC<IBarChartProps> = ({ label, to, availableSpace, 
 
   return (
     <div className={styles.barChart}>
-      {to ? <Link href={to}>{label}</Link> : <label>{label}</label>}
+      {to ? (
+        <Link href={to}>{label}</Link>
+      ) : onClick ? (
+        <label className={styles.link} onClick={(e) => onClick?.(e)}>
+          {label}
+        </label>
+      ) : (
+        <label>{label}</label>
+      )}
       <div className={styles.barLine}>
         <div
           className={styles.percentage}

--- a/src/dashboard/src/components/charts/bar/allocationByVolume/AllocationByVolume.tsx
+++ b/src/dashboard/src/components/charts/bar/allocationByVolume/AllocationByVolume.tsx
@@ -1,27 +1,33 @@
 'use client';
 
 import { IFileSystemItemModel } from '@/hooks';
-import Link from 'next/link';
 import { BarRow, SmallBarChart } from '../smallBar';
 import { IBarChartRowData } from '../smallBar/IBarChartRowData';
+import styles from '../smallBar/SmallBarChart.module.scss';
 import defaultData from './defaultData';
 
 export interface IAllocationByVolumeProps {
   fileSystemItems: IFileSystemItemModel[];
   loading?: boolean;
+  onClick?: (fileSystemItem?: IFileSystemItemModel) => void;
 }
 
-export const AllocationByVolume = ({ fileSystemItems, loading }: IAllocationByVolumeProps) => {
+export const AllocationByVolume = ({
+  fileSystemItems,
+  loading,
+  onClick,
+}: IAllocationByVolumeProps) => {
   return (
     <SmallBarChart
       title="Drive Space"
       data={{
         ...defaultData,
-        datasets: fileSystemItems.map<IBarChartRowData>((fsi) => ({
+        datasets: fileSystemItems.map<IBarChartRowData<IFileSystemItemModel>>((fsi) => ({
           key: fsi.name,
           label: fsi.name,
           capacity: fsi.capacity,
           available: fsi.availableSpace,
+          data: fsi,
         })),
       }}
       exportDisabled={true}
@@ -31,7 +37,17 @@ export const AllocationByVolume = ({ fileSystemItems, loading }: IAllocationByVo
         return data.datasets.map((os) => (
           <BarRow
             key={os.key}
-            label={<Link href="">{os.label}</Link>}
+            label={
+              <p>
+                {onClick ? (
+                  <label className={styles.link} onClick={() => onClick?.(os.data)}>
+                    {os.label}
+                  </label>
+                ) : (
+                  <label>{os.label}</label>
+                )}
+              </p>
+            }
             capacity={os.capacity}
             available={os.available}
           />

--- a/src/dashboard/src/components/charts/bar/allocationByVolume/defaultData.ts
+++ b/src/dashboard/src/components/charts/bar/allocationByVolume/defaultData.ts
@@ -1,7 +1,8 @@
+import { IFileSystemItemModel } from '@/hooks';
 import { IBarChartData } from '../smallBar/IBarChartData';
 import { IBarChartRowData } from '../smallBar/IBarChartRowData';
 
-const defaultData: IBarChartData<IBarChartRowData> = {
+const defaultData: IBarChartData<IBarChartRowData<IFileSystemItemModel>> = {
   labels: ['Drive', 'Allocated', 'Used', 'Unused', 'Percentage Used'],
   datasets: [
     {

--- a/src/dashboard/src/components/charts/bar/smallBar/BarRow.tsx
+++ b/src/dashboard/src/components/charts/bar/smallBar/BarRow.tsx
@@ -3,7 +3,7 @@ import { convertToStorageSize } from './../../../../utils/convertToStorageSize';
 import { IBarChartRowData } from './IBarChartRowData';
 import styles from './SmallBarChart.module.scss';
 
-interface IBarRowProps extends Omit<IBarChartRowData, 'label'> {
+interface IBarRowProps extends Omit<IBarChartRowData<unknown>, 'label'> {
   label: React.ReactNode;
 }
 

--- a/src/dashboard/src/components/charts/bar/smallBar/IBarChartData.ts
+++ b/src/dashboard/src/components/charts/bar/smallBar/IBarChartData.ts
@@ -1,6 +1,6 @@
 import { IBarChartRowData } from './IBarChartRowData';
 
-export interface IBarChartData<T extends IBarChartRowData> {
+export interface IBarChartData<T extends IBarChartRowData<unknown>> {
   labels: string[];
   datasets: T[];
 }

--- a/src/dashboard/src/components/charts/bar/smallBar/IBarChartRowData.ts
+++ b/src/dashboard/src/components/charts/bar/smallBar/IBarChartRowData.ts
@@ -1,6 +1,7 @@
-export interface IBarChartRowData {
+export interface IBarChartRowData<T> {
   key: string;
   label: string;
   capacity: number;
   available: number;
+  data?: T;
 }

--- a/src/dashboard/src/components/charts/bar/smallBar/SmallBarChart.module.scss
+++ b/src/dashboard/src/components/charts/bar/smallBar/SmallBarChart.module.scss
@@ -52,7 +52,7 @@
             background-color: rgba($bc-blue, 0.4);
         }
     }
-    
+
     &:nth-child(3n+2) {
         .percentage {
             background-color: $medium-yellow;
@@ -62,7 +62,7 @@
             background-color: rgba($medium-yellow, 0.4);
         }
     }
-    
+
     &:nth-child(3n+3) {
         .percentage {
             background-color: $bar-chart-gray;
@@ -130,4 +130,8 @@
     top: 5px;
     font-size: $font-size-12;
     color: $info-gray;
+}
+
+.link {
+  cursor: pointer;
 }

--- a/src/dashboard/src/components/charts/bar/smallBar/SmallBarChart.tsx
+++ b/src/dashboard/src/components/charts/bar/smallBar/SmallBarChart.tsx
@@ -4,7 +4,7 @@ import { IBarChartData } from './IBarChartData';
 import { IBarChartRowData } from './IBarChartRowData';
 import styles from './SmallBarChart.module.scss';
 
-export interface ISmallBarChartProps<T extends IBarChartRowData> {
+export interface ISmallBarChartProps<T extends IBarChartRowData<unknown>> {
   /** Title header of the component */
   title?: string;
   /** Data to be displayed in the bar chart */
@@ -17,7 +17,7 @@ export interface ISmallBarChartProps<T extends IBarChartRowData> {
   children?: React.ReactNode | ((data: IBarChartData<T>) => React.ReactNode);
 }
 
-export const SmallBarChart = <T extends IBarChartRowData>({
+export const SmallBarChart = <T extends IBarChartRowData<unknown>>({
   title,
   data,
   children,

--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/hooks/dashboard';
 import { useOperatingSystemItems, useOrganizations, useServerItems } from '@/hooks/data';
 import { useFilteredFileSystemItems } from '@/hooks/filter';
+import { useDashboardFilter } from '.';
 
 /**
  * Dashboard component displays different charts depending on what data has been stored in the dashboard state.
@@ -32,6 +33,8 @@ export const Dashboard = () => {
     useDashboardOperatingSystemItems();
   const { serverItems: dashboardServerItems } = useDashboardServerItems();
   const { fileSystemItems } = useFilteredFileSystemItems();
+
+  const updateDashboard = useDashboardFilter();
 
   const selectedOrganizations = dashboardOrganizations.length
     ? dashboardOrganizations
@@ -69,6 +72,9 @@ export const Dashboard = () => {
           operatingSystemItems={selectedOperatingSystemItems}
           serverItems={selectedServerItems}
           loading={!isReadyOperatingSystemItems || !isReadyServerItems}
+          onClick={async (operatingSystemItem) => {
+            await updateDashboard({ operatingSystemItem });
+          }}
         />
       )}
       {/* One Server Selected */}
@@ -95,6 +101,9 @@ export const Dashboard = () => {
           organizations={selectedOrganizations}
           serverItems={selectedServerItems}
           loading={!isReadyOrganizations || !isReadyServerItems}
+          onClick={async (organization) => {
+            await updateDashboard({ organization });
+          }}
         />
       )}
       {showAllocationTable && (
@@ -102,6 +111,10 @@ export const Dashboard = () => {
           operatingSystem={selectedServerItems[0].className}
           serverItems={selectedServerItems}
           loading={!isReadyServerItems || !isReadyOperatingSystemItems}
+          onClick={async (serverItem) => {
+            console.debug(serverItem);
+            await updateDashboard({ serverItem });
+          }}
         />
       )}
       {showSegmentedBarChart && (

--- a/src/dashboard/src/components/dashboard/index.ts
+++ b/src/dashboard/src/components/dashboard/index.ts
@@ -1,1 +1,2 @@
 export * from './Dashboard';
+export * from './useDashboardFilter';

--- a/src/dashboard/src/components/dashboard/useDashboardFilter.ts
+++ b/src/dashboard/src/components/dashboard/useDashboardFilter.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import {
+  IOperatingSystemItemModel,
+  IOrganizationModel,
+  IServerItemModel,
+  ITenantModel,
+} from '@/hooks';
+import { useDashboardServerHistoryItems } from '@/hooks/dashboard';
+import {
+  useFilteredFileSystemItems,
+  useFilteredOperatingSystemItems,
+  useFilteredOrganizations,
+  useFilteredTenants,
+} from '@/hooks/filter';
+import { useDashboard, useFiltered } from '@/store';
+import React from 'react';
+
+export interface IDashboardFilterProps {
+  tenant?: ITenantModel;
+  organization?: IOrganizationModel;
+  operatingSystemItem?: IOperatingSystemItemModel;
+  serverItem?: IServerItemModel;
+}
+
+/**
+ * Hook provides a function to update dashboard state.
+ * The function will apply the current filter to the dashboard, or will update the filter based on the passed in selected values.
+ * @returns Function to update dashboard state.
+ */
+export const useDashboardFilter = () => {
+  const setDashboardTenants = useDashboard((state) => state.setTenants);
+  const setDashboardOrganizations = useDashboard((state) => state.setOrganizations);
+  const setDashboardOperatingSystemItems = useDashboard((state) => state.setOperatingSystemItems);
+  const setDashboardServerItems = useDashboard((state) => state.setServerItems);
+  const setDashboardDateRange = useDashboard((state) => state.setDateRange);
+  const { findFileSystemItems } = useFilteredFileSystemItems();
+  const { findServerHistoryItems } = useDashboardServerHistoryItems();
+
+  const filteredTenant = useFiltered((state) => state.tenant);
+  const setFilteredTenant = useFiltered((state) => state.setTenant);
+  const { tenants: filteredTenants } = useFilteredTenants();
+  const filteredOrganization = useFiltered((state) => state.organization);
+  const setFilteredOrganization = useFiltered((state) => state.setOrganization);
+  const { organizations: filteredOrganizations } = useFilteredOrganizations();
+  const filteredOperatingSystemItem = useFiltered((state) => state.operatingSystemItem);
+  const setFilteredOperatingSystemItem = useFiltered((state) => state.setOperatingSystemItem);
+  const { operatingSystemItems: filteredOperatingSystemItems } = useFilteredOperatingSystemItems();
+  const filteredServerItem = useFiltered((state) => state.serverItem);
+  const setFilteredServerItem = useFiltered((state) => state.setServerItem);
+  const filteredServerItems = useFiltered((state) => state.serverItems);
+  const filteredDateRange = useFiltered((state) => state.dateRange);
+
+  return React.useCallback(
+    async (filter?: IDashboardFilterProps) => {
+      const selectedTenant = filter?.tenant ?? filteredTenant;
+      const selectedOrganization = filter?.organization ?? filteredOrganization;
+      const selectedOperatingSystemItem =
+        filter?.operatingSystemItem ?? filteredOperatingSystemItem;
+      const selectedServerItem = filter?.serverItem ?? filteredServerItem;
+
+      if (filter?.tenant) setFilteredTenant(filter?.tenant);
+      if (selectedTenant) setDashboardTenants([selectedTenant]);
+      else setDashboardTenants(filteredTenants);
+
+      if (filter?.organization) setFilteredOrganization(filter?.organization);
+      if (selectedOrganization) setDashboardOrganizations([selectedOrganization]);
+      else setDashboardOrganizations(filteredOrganizations);
+
+      if (filter?.operatingSystemItem) setFilteredOperatingSystemItem(filter?.operatingSystemItem);
+      if (selectedOperatingSystemItem)
+        setDashboardOperatingSystemItems([selectedOperatingSystemItem]);
+      else setDashboardOperatingSystemItems(filteredOperatingSystemItems);
+
+      if (filter?.serverItem) setFilteredServerItem(filter?.serverItem);
+      if (selectedServerItem) setDashboardServerItems([selectedServerItem]);
+      else setDashboardServerItems(filteredServerItems);
+
+      setDashboardDateRange(filteredDateRange);
+
+      if (filteredServerItem)
+        await findFileSystemItems({
+          serverItemServiceNowKey: filteredServerItem.serviceNowKey,
+        });
+
+      await findServerHistoryItems({
+        startDate: filteredDateRange[0] ? filteredDateRange[0] : undefined,
+        endDate: filteredDateRange[1] ? filteredDateRange[1] : undefined,
+        tenantId: filteredTenant?.id,
+        organizationId: filteredOrganization?.id,
+        operatingSystemItemId: filteredOperatingSystemItem?.id,
+        serviceNowKey: filteredServerItem?.serviceNowKey,
+      });
+    },
+    [
+      filteredDateRange,
+      filteredOperatingSystemItem,
+      filteredOperatingSystemItems,
+      filteredOrganization,
+      filteredOrganizations,
+      filteredServerItem,
+      filteredServerItems,
+      filteredTenant,
+      filteredTenants,
+      findFileSystemItems,
+      findServerHistoryItems,
+      setDashboardDateRange,
+      setDashboardOperatingSystemItems,
+      setDashboardOrganizations,
+      setDashboardServerItems,
+      setDashboardTenants,
+      setFilteredOperatingSystemItem,
+      setFilteredOrganization,
+      setFilteredServerItem,
+      setFilteredTenant,
+    ],
+  );
+};

--- a/src/dashboard/src/components/filter/Filter.tsx
+++ b/src/dashboard/src/components/filter/Filter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, DateRangePicker, Select } from '@/components';
+import { Button, DateRangePicker, Select, useDashboardFilter } from '@/components';
 import { IOperatingSystemItemModel, IOrganizationModel, ITenantModel, useAuth } from '@/hooks';
 import { useDashboardServerHistoryItems } from '@/hooks/dashboard';
 import {
@@ -68,6 +68,8 @@ export const Filter: React.FC = () => {
   const { isReady: serverHistoryItemsReady, findServerHistoryItems } =
     useDashboardServerHistoryItems();
   const { findFileSystemItems } = useFilteredFileSystemItems();
+
+  const updateDashboard = useDashboardFilter();
 
   const enableTenants = isHSB || tenants.length > 1;
   const enableOrganizations = isHSB || organizations.length > 1;
@@ -250,34 +252,7 @@ export const Filter: React.FC = () => {
         }
         loading={!serverHistoryItemsReady}
         onClick={async () => {
-          if (filteredTenant) setDashboardTenants([filteredTenant]);
-          else setDashboardTenants(filteredTenants);
-
-          if (filteredOrganization) setDashboardOrganizations([filteredOrganization]);
-          else setDashboardOrganizations(filteredOrganizations);
-
-          if (filteredOperatingSystemItem)
-            setDashboardOperatingSystemItems([filteredOperatingSystemItem]);
-          else setDashboardOperatingSystemItems(filteredOperatingSystemItems);
-
-          if (filteredServerItem) setDashboardServerItems([filteredServerItem]);
-          else setDashboardServerItems(filteredServerItems);
-
-          setDashboardDateRange(filteredDateRange);
-
-          if (filteredServerItem)
-            await findFileSystemItems({
-              serverItemServiceNowKey: filteredServerItem.serviceNowKey,
-            });
-
-          await findServerHistoryItems({
-            startDate: filteredDateRange[0] ? filteredDateRange[0] : undefined,
-            endDate: filteredDateRange[1] ? filteredDateRange[1] : undefined,
-            tenantId: filteredTenant?.id,
-            organizationId: filteredOrganization?.id,
-            operatingSystemItemId: filteredOperatingSystemItem?.id,
-            serviceNowKey: filteredServerItem?.serviceNowKey,
-          });
+          await updateDashboard();
         }}
       >
         Update


### PR DESCRIPTION
Client users now have the various dashboard views and the All Servers page.

I have also updated charts that had links (organization, operating system, server) to update the filter when they are clicked.  I think I'll need to go back and update this functionality to support the back button however.

## Dashboard Single Server

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/4be2c541-4be9-41cf-990d-f3d88e0dfe75)

## Dashboard Single OS

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/f2bd102a-a0b8-45c8-b0db-306776f1c0f8)

## Single Organization

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/faace75a-1f7c-4da5-96df-0b752a645677)

## Multiple Organizations

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/aefe5c00-0e3d-4335-9ecc-1d3b69cba2cb)

## All Servers

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/d414bf83-0778-4557-9444-3b91f450de21)

