### PR TITLE
Wire up all servers

### DIFF
--- a/src/dashboard/src/app/api/dashboard/server-items/[id]/route.ts
+++ b/src/dashboard/src/app/api/dashboard/server-items/[id]/route.ts
@@ -2,5 +2,5 @@ import { dispatch } from '@/app/api/utils';
 
 export async function GET(req: Request, context: { params: any }) {
   const url = new URL(req.url);
-  return await dispatch(`/v1/dashboard/server-items/${context.params.id}`);
+  return await dispatch(`/v1/dashboard/server-items/${context.params.id}${url.search}`);
 }

--- a/src/dashboard/src/app/client/servers/page.tsx
+++ b/src/dashboard/src/app/client/servers/page.tsx
@@ -3,20 +3,34 @@
 import { AllocationTable, Col } from '@/components';
 import { useAuth } from '@/hooks';
 import { useServerItems } from '@/hooks/data';
-import { redirect } from 'next/navigation';
+import { useDashboard, useFiltered } from '@/store';
+import { redirect, useRouter } from 'next/navigation';
 
 export default function Page() {
+  const router = useRouter();
   const state = useAuth();
-  const { isReady, serverItems } = useServerItems();
+  const { isReady, serverItems } = useServerItems({ useSimple: true, init: true });
+  const setFilteredServerItem = useFiltered((state) => state.setServerItem);
+  const setDashboardServerItems = useDashboard((state) => state.setServerItems);
 
-  // Only allow Client role to view this page.
+  // Only allow HSB role to view this page.
   if (state.status === 'loading') return <div>Loading...</div>;
   if (!state.isClient) redirect('/');
 
   return (
     <Col>
       <h1>All Servers</h1>
-      <AllocationTable serverItems={serverItems} loading={!isReady} />
+      <AllocationTable
+        serverItems={serverItems}
+        loading={!isReady}
+        onClick={(serverItem) => {
+          if (serverItem) {
+            setFilteredServerItem(serverItem);
+            setDashboardServerItems([serverItem]);
+            router.push(`/client/dashboard?serverItem=${serverItem?.serviceNowKey}`);
+          }
+        }}
+      />
     </Col>
   );
 }

--- a/src/dashboard/src/app/hsb/servers/page.tsx
+++ b/src/dashboard/src/app/hsb/servers/page.tsx
@@ -3,11 +3,15 @@
 import { AllocationTable, Col } from '@/components';
 import { useAuth } from '@/hooks';
 import { useServerItems } from '@/hooks/data';
-import { redirect } from 'next/navigation';
+import { useDashboard, useFiltered } from '@/store';
+import { redirect, useRouter } from 'next/navigation';
 
 export default function Page() {
+  const router = useRouter();
   const state = useAuth();
-  const { isReady, serverItems } = useServerItems();
+  const { isReady, serverItems } = useServerItems({ useSimple: true, init: true });
+  const setFilteredServerItem = useFiltered((state) => state.setServerItem);
+  const setDashboardServerItems = useDashboard((state) => state.setServerItems);
 
   // Only allow HSB role to view this page.
   if (state.status === 'loading') return <div>Loading...</div>;
@@ -16,7 +20,17 @@ export default function Page() {
   return (
     <Col>
       <h1>All Servers</h1>
-      <AllocationTable serverItems={serverItems} loading={!isReady} />
+      <AllocationTable
+        serverItems={serverItems}
+        loading={!isReady}
+        onClick={(serverItem) => {
+          if (serverItem) {
+            setFilteredServerItem(serverItem);
+            setDashboardServerItems([serverItem]);
+            router.push(`/hsb/dashboard?serverItem=${serverItem?.serviceNowKey}`);
+          }
+        }}
+      />
     </Col>
   );
 }

--- a/src/dashboard/src/components/charts/bar/allocationByOS/AllocationByOS.tsx
+++ b/src/dashboard/src/components/charts/bar/allocationByOS/AllocationByOS.tsx
@@ -37,7 +37,7 @@ export const AllocationByOS = ({
                     {os.label}
                   </label>
                 ) : (
-                  <p>{os.label}</p>
+                  os.label
                 )}
               </p>
             }

--- a/src/dashboard/src/components/charts/bar/segmentedBarChart/useStorageTrends.ts
+++ b/src/dashboard/src/components/charts/bar/segmentedBarChart/useStorageTrends.ts
@@ -27,8 +27,9 @@ interface IStorageTrendsData extends ChartData<'bar', number[], string> {
 export const useStorageTrends = (
   minColumns: number = 1,
   maxVolumes: number = 4,
+  dateRange: string[] = [],
 ): IStorageTrendsData => {
-  const groups = useStorageHistoryDateRange<IFileSystemHistoryItemModel>(minColumns);
+  const groups = useStorageHistoryDateRange<IFileSystemHistoryItemModel>(minColumns, dateRange);
   const fileSystemHistoryItems = useDashboard((state) => state.fileSystemHistoryItems);
 
   return React.useMemo(() => {

--- a/src/dashboard/src/components/charts/hooks/useStorageHistoryDateRange.ts
+++ b/src/dashboard/src/components/charts/hooks/useStorageHistoryDateRange.ts
@@ -1,4 +1,3 @@
-import { useDashboard } from '@/store';
 import { calcMonthsBetween } from '@/utils';
 import moment from 'moment';
 
@@ -16,9 +15,7 @@ export interface IDateRangeStorageHistoryData<T> {
  * @param minColumns Minimum number of columns
  * @returns An array of months to contain history for each month.
  */
-export const useStorageHistoryDateRange = <T>(minColumns: number = 1) => {
-  const dateRange = useDashboard((state) => state.dateRange);
-
+export const useStorageHistoryDateRange = <T>(minColumns: number = 1, dateRange: string[] = []) => {
   const now = moment();
   const start = dateRange[0]
     ? moment(dateRange[0])

--- a/src/dashboard/src/components/charts/storageTrends/StorageTrendsChart.tsx
+++ b/src/dashboard/src/components/charts/storageTrends/StorageTrendsChart.tsx
@@ -17,11 +17,19 @@ import { useStorageTrends } from './useStorageTrends';
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
 interface LineChartProps {
+  minColumns?: number;
   large?: boolean;
+  loading?: boolean;
+  dateRange?: string[];
 }
 
-export const StorageTrendsChart: React.FC<LineChartProps> = ({ large }) => {
-  const data = useStorageTrends();
+export const StorageTrendsChart: React.FC<LineChartProps> = ({
+  large,
+  loading,
+  minColumns,
+  dateRange,
+}) => {
+  const data = useStorageTrends(minColumns, dateRange);
 
   return <LineChart data={data} label="Storage Trends" large={large} showExport exportDisabled />;
 };

--- a/src/dashboard/src/components/charts/storageTrends/useStorageTrends.ts
+++ b/src/dashboard/src/components/charts/storageTrends/useStorageTrends.ts
@@ -11,8 +11,11 @@ import { useStorageHistoryDateRange } from '../hooks';
  * @param minColumns Minimum number of columns in the line chard (default = 1).
  * @returns Line chart data.
  */
-export const useStorageTrends = (minColumns: number = 1): ChartData<'line', number[], string> => {
-  const groups = useStorageHistoryDateRange(minColumns);
+export const useStorageTrends = (
+  minColumns: number = 1,
+  dateRange: string[] = [],
+): ChartData<'line', number[], string> => {
+  const groups = useStorageHistoryDateRange(minColumns, dateRange);
   const serverHistoryItems = useDashboard((state) => state.serverHistoryItems);
 
   return React.useMemo(() => {

--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/hooks/dashboard';
 import { useOperatingSystemItems, useOrganizations, useServerItems } from '@/hooks/data';
 import { useFilteredFileSystemItems } from '@/hooks/filter';
+import { useDashboard } from '@/store';
 import { useDashboardFilter } from '.';
 
 /**
@@ -27,11 +28,12 @@ import { useDashboardFilter } from '.';
 export const Dashboard = () => {
   const { isReady: isReadyOrganizations, organizations } = useOrganizations();
   const { isReady: isReadyOperatingSystemItems, operatingSystemItems } = useOperatingSystemItems();
-  const { isReady: isReadyServerItems, serverItems } = useServerItems();
+  const { isReady: isReadyServerItems, serverItems } = useServerItems({ useSimple: true });
   const { organizations: dashboardOrganizations } = useDashboardOrganizations();
   const { operatingSystemItems: dashboardOperatingSystemItems } =
     useDashboardOperatingSystemItems();
   const { serverItems: dashboardServerItems } = useDashboardServerItems();
+  const dateRange = useDashboard((state) => state.dateRange);
   const { fileSystemItems } = useFilteredFileSystemItems();
 
   const updateDashboard = useDashboardFilter();
@@ -95,6 +97,7 @@ export const Dashboard = () => {
           selectedOperatingSystemItems.length === 1 ||
           selectedServerItems.length === 1
         }
+        dateRange={dateRange}
       />
       {showAllocationByStorageVolume && (
         <AllocationByStorageVolume
@@ -118,7 +121,11 @@ export const Dashboard = () => {
         />
       )}
       {showSegmentedBarChart && (
-        <SegmentedBarChart serverItem={selectedServerItems[0]} loading={!isReadyServerItems} />
+        <SegmentedBarChart
+          serverItem={selectedServerItems[0]}
+          loading={!isReadyServerItems}
+          dateRange={dateRange}
+        />
       )}
     </>
   );

--- a/src/dashboard/src/components/filter/hooks/index.ts
+++ b/src/dashboard/src/components/filter/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useUrlParamsUpdateKey';

--- a/src/dashboard/src/components/filter/hooks/useUrlParamsUpdateKey.ts
+++ b/src/dashboard/src/components/filter/hooks/useUrlParamsUpdateKey.ts
@@ -1,0 +1,33 @@
+import { useSearchParams } from 'next/navigation';
+import React from 'react';
+
+/**
+ * Generates a lock and an initial key to control when the dashboard should be updated based on the URL parameters.
+ * Without this it will update the dashboard multiple times.
+ * @returns Two keys that must match before it will update the dashboard.
+ */
+export const useUrlParamsUpdateKey = () => {
+  const params = useSearchParams();
+
+  const currentParams = React.useMemo(
+    () => new URLSearchParams(Array.from(params.entries())),
+    [params],
+  );
+
+  const readyKey = React.useRef(0);
+  var lockKey = 0;
+
+  // Extract URL query parameters and initialize state.
+  const tenantId = currentParams.get('tenant');
+  const organizationId = currentParams.get('organization');
+  const operatingSystemItemId = currentParams.get('operatingSystemItem');
+  const serverItemKey = currentParams.get('serverItem');
+
+  // Generate a lock that matches the provided URL parameters.
+  if (tenantId) lockKey = lockKey | 1;
+  if (organizationId) lockKey = lockKey | 2;
+  if (operatingSystemItemId) lockKey = lockKey | 4;
+  if (serverItemKey) lockKey = lockKey | 8;
+
+  return { readyKey, lockKey };
+};

--- a/src/dashboard/src/components/header/Header.tsx
+++ b/src/dashboard/src/components/header/Header.tsx
@@ -33,12 +33,13 @@ export const Header: React.FC = () => {
   const rootPath = isHSB ? 'hsb' : 'client';
   const infoIcon = false;
   const isDashboardView = path.includes('/dashboard');
+  const isServerView = path.includes('/servers');
   const isAdminView = path.includes('/admin');
 
   return (
     <>
       <header
-        className={`${style.header} ${isDashboardView && style.filterPadding} ${
+        className={`${style.header} ${(isDashboardView || isServerView) && style.filterPadding} ${
           isAdminView && style.adminPadding
         }`}
       >
@@ -91,12 +92,12 @@ export const Header: React.FC = () => {
                             </Link>
                           )}
                         </nav>
-                        {isDashboardView && (
+                        {(isDashboardView || isServerView) && (
                           <Link href={`/${rootPath}/servers`} className={style.allServers}>
                             See all servers
                           </Link>
                         )}
-                        {isSystemAdmin && !isDashboardView && (
+                        {isSystemAdmin && !isDashboardView && !isServerView && (
                           <>
                             <nav>
                               <div className={style.adminNav}>

--- a/src/dashboard/src/hooks/api/useApiServerItems.ts
+++ b/src/dashboard/src/hooks/api/useApiServerItems.ts
@@ -13,6 +13,19 @@ export const useApiServerItems = () => {
       find: async (filter: IServerItemFilter | undefined = {}): Promise<Response> => {
         return await dispatch(`/api/dashboard/server-items?${toQueryString(filter)}`);
       },
+      findSimple: async (filter: IServerItemFilter | undefined = {}): Promise<Response> => {
+        return await dispatch(`/api/dashboard/server-items/simple?${toQueryString(filter)}`);
+      },
+      get: async (
+        serviceNowKey: string,
+        includeFileSystemItems: boolean = false,
+      ): Promise<Response> => {
+        return await dispatch(
+          `/api/dashboard/server-items/${serviceNowKey}?${toQueryString({
+            includeFileSystemItems,
+          })}`,
+        );
+      },
       history: async (filter: IServerHistoryItemFilter | undefined = {}): Promise<Response> => {
         return await dispatch(`/api/dashboard/server-items/history?${toQueryString(filter)}`);
       },

--- a/src/dashboard/src/hooks/data/useGroups.ts
+++ b/src/dashboard/src/hooks/data/useGroups.ts
@@ -4,17 +4,23 @@ import React from 'react';
 import { IGroupModel, useAuth } from '..';
 import { useApiGroups } from '../api/admin';
 
-export const useGroups = () => {
+export interface IGroupsProps {
+  init?: boolean;
+}
+
+export const useGroups = ({ init }: IGroupsProps = {}) => {
   const { status } = useAuth();
   const { find } = useApiGroups();
   const groups = useApp((state) => state.groups);
   const setGroups = useApp((state) => state.setGroups);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of groups.
-    if (status === 'authenticated' && !groups.length) {
+    if (status === 'authenticated' && !groups.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
       find()
         .then(async (res) => {
@@ -24,9 +30,12 @@ export const useGroups = () => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (groups.length) setIsReady(true);
-  }, [find, setGroups, status, groups.length]);
+  }, [find, setGroups, status, groups.length, isLoading, isReady, init]);
 
   const options = React.useMemo(
     () =>

--- a/src/dashboard/src/hooks/data/useOperatingSystemItems.ts
+++ b/src/dashboard/src/hooks/data/useOperatingSystemItems.ts
@@ -2,17 +2,29 @@ import { useApp } from '@/store';
 import React from 'react';
 import { IOperatingSystemItemModel, useApiOperatingSystemItems, useAuth } from '..';
 
-export const useOperatingSystemItems = () => {
+export interface IOperatingSystemItemsProps {
+  init?: boolean;
+}
+
+export const useOperatingSystemItems = ({ init }: IOperatingSystemItemsProps = {}) => {
   const { status } = useAuth();
   const { find } = useApiOperatingSystemItems();
   const operatingSystemItems = useApp((state) => state.operatingSystemItems);
   const setOperatingSystemItems = useApp((state) => state.setOperatingSystemItems);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of operatingSystemItems.
-    if (status === 'authenticated' && !operatingSystemItems.length) {
+    if (
+      status === 'authenticated' &&
+      !operatingSystemItems.length &&
+      !isLoading &&
+      !isReady &&
+      init
+    ) {
+      setIsLoading(true);
       setIsReady(false);
       find()
         .then(async (res) => {
@@ -22,9 +34,20 @@ export const useOperatingSystemItems = () => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (operatingSystemItems.length) setIsReady(true);
-  }, [find, setOperatingSystemItems, status, operatingSystemItems.length]);
+  }, [
+    find,
+    setOperatingSystemItems,
+    status,
+    operatingSystemItems.length,
+    isLoading,
+    isReady,
+    init,
+  ]);
 
   return { isReady, operatingSystemItems };
 };

--- a/src/dashboard/src/hooks/data/useOrganizations.ts
+++ b/src/dashboard/src/hooks/data/useOrganizations.ts
@@ -2,17 +2,23 @@ import { useApp } from '@/store';
 import React from 'react';
 import { IOrganizationModel, useApiOrganizations, useAuth } from '..';
 
-export const useOrganizations = () => {
+export interface IOrganizationsProps {
+  init?: boolean;
+}
+
+export const useOrganizations = ({ init }: IOrganizationsProps = {}) => {
   const { status } = useAuth();
   const { find } = useApiOrganizations();
   const organizations = useApp((state) => state.organizations);
   const setOrganizations = useApp((state) => state.setOrganizations);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of organizations.
-    if (status === 'authenticated' && !organizations.length) {
+    if (status === 'authenticated' && !organizations.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
       find()
         .then(async (res) => {
@@ -22,9 +28,12 @@ export const useOrganizations = () => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (organizations.length) setIsReady(true);
-  }, [find, setOrganizations, status, organizations.length]);
+  }, [find, setOrganizations, status, organizations.length, isLoading, isReady, init]);
 
   return { isReady, organizations };
 };

--- a/src/dashboard/src/hooks/data/useRoles.ts
+++ b/src/dashboard/src/hooks/data/useRoles.ts
@@ -4,17 +4,23 @@ import React from 'react';
 import { IRoleModel, useAuth } from '..';
 import { useApiRoles } from '../api/admin';
 
-export const useRoles = () => {
+export interface IUsersProps {
+  init?: boolean;
+}
+
+export const useRoles = ({ init }: IUsersProps = {}) => {
   const { status } = useAuth();
   const { find } = useApiRoles();
   const roles = useApp((state) => state.roles);
   const setRoles = useApp((state) => state.setRoles);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of roles.
-    if (status === 'authenticated' && !roles.length) {
+    if (status === 'authenticated' && !roles.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
       find()
         .then(async (res) => {
@@ -24,9 +30,12 @@ export const useRoles = () => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (roles.length) setIsReady(true);
-  }, [find, setRoles, status, roles.length]);
+  }, [find, setRoles, status, roles.length, isLoading, isReady, init]);
 
   const options = React.useMemo(
     () =>

--- a/src/dashboard/src/hooks/data/useServerItems.ts
+++ b/src/dashboard/src/hooks/data/useServerItems.ts
@@ -2,29 +2,66 @@ import { useApp } from '@/store';
 import React from 'react';
 import { IServerItemModel, useApiServerItems, useAuth } from '..';
 
-export const useServerItems = () => {
+export interface IServerItemsProps {
+  useSimple?: boolean;
+  init?: boolean;
+}
+
+export const useServerItems = (
+  { useSimple = false, init }: IServerItemsProps = { useSimple: false },
+) => {
   const { status } = useAuth();
-  const { find } = useApiServerItems();
+  const { find, findSimple } = useApiServerItems();
   const serverItems = useApp((state) => state.serverItems);
   const setServerItems = useApp((state) => state.setServerItems);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of serverItems.
-    if (status === 'authenticated' && !serverItems.length) {
+    if (status === 'authenticated' && !serverItems.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
-      find()
-        .then(async (res) => {
-          const serverItems: IServerItemModel[] = await res.json();
-          setServerItems(serverItems);
-        })
-        .catch((error) => {
-          console.error(error);
-        })
-        .finally(() => setIsReady(true));
+      if (useSimple) {
+        findSimple()
+          .then(async (res) => {
+            const serverItems: IServerItemModel[] = await res.json();
+            setServerItems(serverItems);
+          })
+          .catch((error) => {
+            console.error(error);
+          })
+          .finally(() => {
+            setIsReady(true);
+            setIsLoading(false);
+          });
+      } else {
+        find()
+          .then(async (res) => {
+            const serverItems: IServerItemModel[] = await res.json();
+            setServerItems(serverItems);
+          })
+          .catch((error) => {
+            console.error(error);
+          })
+          .finally(() => {
+            setIsReady(true);
+            setIsLoading(false);
+          });
+      }
     } else if (serverItems.length) setIsReady(true);
-  }, [find, setServerItems, status, serverItems.length]);
+  }, [
+    find,
+    setServerItems,
+    status,
+    serverItems.length,
+    useSimple,
+    findSimple,
+    isLoading,
+    isReady,
+    init,
+  ]);
 
   return { isReady, serverItems };
 };

--- a/src/dashboard/src/hooks/data/useTenants.ts
+++ b/src/dashboard/src/hooks/data/useTenants.ts
@@ -2,17 +2,23 @@ import { useApp } from '@/store';
 import React from 'react';
 import { ITenantModel, useApiTenants, useAuth } from '..';
 
-export const useTenants = () => {
+export interface ITenantsProps {
+  init?: boolean;
+}
+
+export const useTenants = ({ init }: ITenantsProps = {}) => {
   const { status } = useAuth();
   const { find } = useApiTenants();
   const tenants = useApp((state) => state.tenants);
   const setTenants = useApp((state) => state.setTenants);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of tenants.
-    if (status === 'authenticated' && !tenants.length) {
+    if (status === 'authenticated' && !tenants.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
       find()
         .then(async (res) => {
@@ -22,9 +28,12 @@ export const useTenants = () => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (tenants.length) setIsReady(true);
-  }, [find, setTenants, status, tenants.length]);
+  }, [find, init, isLoading, isReady, setTenants, status, tenants.length]);
 
   return { isReady, tenants };
 };

--- a/src/dashboard/src/hooks/data/useUsers.ts
+++ b/src/dashboard/src/hooks/data/useUsers.ts
@@ -6,9 +6,10 @@ import { useApiUsers } from '../api/admin';
 
 interface IUserProps {
   includeGroups?: boolean;
+  init?: boolean;
 }
 
-export const useUsers = ({ includeGroups }: IUserProps) => {
+export const useUsers = ({ includeGroups, init }: IUserProps = {}) => {
   const { status } = useAuth();
   const { find, get } = useApiUsers();
   const userInfo = useApp((state) => state.userinfo);
@@ -16,10 +17,12 @@ export const useUsers = ({ includeGroups }: IUserProps) => {
   const setUsers = useApp((state) => state.setUsers);
 
   const [isReady, setIsReady] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
 
   React.useEffect(() => {
     // Get an array of all users.
-    if (status === 'authenticated' && !users.length) {
+    if (status === 'authenticated' && !users.length && !isLoading && !isReady && init) {
+      setIsLoading(true);
       setIsReady(false);
       find({ includeGroups })
         .then(async (res) => {
@@ -29,9 +32,12 @@ export const useUsers = ({ includeGroups }: IUserProps) => {
         .catch((error) => {
           console.error(error);
         })
-        .finally(() => setIsReady(true));
+        .finally(() => {
+          setIsReady(true);
+          setIsLoading(false);
+        });
     } else if (users.length) setIsReady(true);
-  }, [find, includeGroups, setUsers, status, users.length]);
+  }, [find, includeGroups, init, isLoading, isReady, setUsers, status, users.length]);
 
   React.useEffect(() => {
     // When a page is first loaded a request is made to activate the user.

--- a/src/dashboard/src/hooks/filter/useFilteredServerItems.ts
+++ b/src/dashboard/src/hooks/filter/useFilteredServerItems.ts
@@ -3,19 +3,25 @@ import { useFiltered } from '@/store';
 import React from 'react';
 import { IServerItemFilter, IServerItemModel, useApiServerItems } from '..';
 
-export const useFilteredServerItems = () => {
-  const { find } = useApiServerItems();
+export interface IFilteredServerItemsProps {
+  useSimple?: boolean;
+}
+
+export const useFilteredServerItems = (
+  { useSimple = false }: IFilteredServerItemsProps | undefined = { useSimple: false },
+) => {
+  const { find, findSimple } = useApiServerItems();
   const serverItems = useFiltered((state) => state.serverItems);
   const setFilteredServerItems = useFiltered((state) => state.setServerItems);
 
   const fetch = React.useCallback(
     async (filter: IServerItemFilter) => {
-      const res = await find(filter);
+      const res = useSimple ? await findSimple(filter) : await find(filter);
       const serverItems: IServerItemModel[] = await res.json();
       setFilteredServerItems(serverItems);
       return serverItems;
     },
-    [find, setFilteredServerItems],
+    [find, findSimple, setFilteredServerItems, useSimple],
   );
 
   const options = React.useMemo(

--- a/src/dashboard/src/store/useApp.ts
+++ b/src/dashboard/src/store/useApp.ts
@@ -86,18 +86,3 @@ export const useApp = create<IAppState>((set) => ({
   fileSystemItems: [],
   setFileSystemItems: (values) => set((state) => ({ fileSystemItems: values })),
 }));
-
-// export const useApp2 = create(
-//   persist(
-//     (set, get): IAppState => ({
-//       userinfo: undefined,
-//       setUserinfo: (value) => set((state: IAppState) => ({ userinfo: value })),
-//       tenants: [],
-//       setTenants: (tenants) => set((state: IAppState) => ({ tenants })),
-//     }),
-//     {
-//       name: 'test',
-//       storage: createJSONStorage(() => sessionStorage),
-//     },
-//   ),
-// );

--- a/src/data-service/Config/ServiceNowTableNameOptions.cs
+++ b/src/data-service/Config/ServiceNowTableNameOptions.cs
@@ -14,61 +14,6 @@ public class ServiceNowTableNameOptions
     /// <summary>
     /// get/set -
     /// </summary>
-    public string Server { get; set; } = "cmdb_ci_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string WinServer { get; set; } = "cmdb_ci_win_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string SolarisServer { get; set; } = "cmdb_ci_solaris_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string LinuxServer { get; set; } = "cmdb_ci_linux_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string UnixServer { get; set; } = "cmdb_ci_unix_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string EsxServer { get; set; } = "cmdb_ci_esx_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string AixServer { get; set; } = "cmdb_ci_aix_server";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string Appliance { get; set; } = "u_cmdb_ci_appliance";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string PCHardware { get; set; } = "cmdb_ci_pc_hardware";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string FileSystem { get; set; } = "cmdb_ci_file_system";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
-    public string OpenVMS { get; set; } = "u_openvms";
-
-    /// <summary>
-    /// get/set -
-    /// </summary>
     public string Tenant { get; set; } = "u_tenant";
 
     /// <summary>

--- a/src/data-service/Config/ServiceOptions.cs
+++ b/src/data-service/Config/ServiceOptions.cs
@@ -20,5 +20,15 @@ public class ServiceOptions
     /// get/set - An array of data sync configuration items to run in this service.
     /// </summary>
     public Models.DataSyncModel[] DataSync { get; set; } = Array.Empty<Models.DataSyncModel>();
+
+    /// <summary>
+    /// get/set - An array of table names that represent mapped volumes and drives.
+    /// </summary>
+    public string[] VolumeTableNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// get/set - An array of table names that represent servers/devices/computers.
+    /// </summary>
+    public string[] ServerTableNames { get; set; } = Array.Empty<string>();
     #endregion
 }

--- a/src/data-service/DataService.cs
+++ b/src/data-service/DataService.cs
@@ -185,7 +185,7 @@ public class DataService : IDataService
                     continue;
                 }
 
-                if (tableName == this.ServiceNowApi.Options.TableNames.FileSystem)
+                if (this.Options.VolumeTableNames.Contains(tableName))
                 {
                     // Get the specific type of item this configuration is for.
                     var itemSN = await this.ServiceNowApi.GetTableItemAsync<ServiceNow.FileSystemModel>(tableName, configurationItemSN.Data.Id);
@@ -197,7 +197,7 @@ public class DataService : IDataService
 
                     await ProcessFileSystemItemAsync(itemSN, configurationItemSN);
                 }
-                else
+                else if (this.Options.ServerTableNames.Contains(tableName))
                 {
                     // Get the specific type of item this configuration is for.
                     var itemSN = await this.ServiceNowApi.GetTableItemAsync<ServiceNow.BaseItemModel>(tableName, configurationItemSN.Data.Id);
@@ -208,6 +208,10 @@ public class DataService : IDataService
                     }
 
                     await ProcessServerItemAsync(itemSN, configurationItemSN);
+                }
+                else
+                {
+                    this.Logger.LogWarning("Data Service configuration is not currently configured to support this class name: {tableName}", tableName);
                 }
 
                 // Update the current offset

--- a/src/data-service/appsettings.json
+++ b/src/data-service/appsettings.json
@@ -10,7 +10,20 @@
     }
   },
   "Service": {
-    "ApiUrl": "http://api:8080"
+    "ApiUrl": "http://api:8080",
+    "VolumeTableNames": ["cmdb_ci_file_system"],
+    "ServerTableNames": [
+      "cmdb_ci_server",
+      "cmdb_ci_win_server",
+      "cmdb_ci_solaris_server",
+      "cmdb_ci_linux_server",
+      "cmdb_ci_unix_server",
+      "cmdb_ci_esx_server",
+      "cmdb_ci_aix_server",
+      "u_cmdb_ci_appliance",
+      "cmdb_ci_pc_hardware",
+      "u_openvms"
+    ]
   },
   "ServiceNow": {
     "Username": "{DO NOT KEEP SECRET HERE}",

--- a/src/libs/dal/HSBContext.cs
+++ b/src/libs/dal/HSBContext.cs
@@ -6,8 +6,6 @@ using HSB.DAL.Extensions;
 using HSB.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -15,6 +13,7 @@ namespace HSB.DAL;
 public class HSBContext : DbContext
 {
     #region Variables
+    private readonly ILoggerFactory? _loggerFactory;
     private readonly ILogger? _logger;
     private readonly IHttpContextAccessor? _httpContextAccessor;
     private readonly JsonSerializerOptions? _serializerOptions;
@@ -42,10 +41,11 @@ public class HSBContext : DbContext
     /// <summary>
     /// Creates a new instance of a SiteContext object, initializes with specified parameters.
     /// </summary>
-    /// <param name="logger"></param>
-    protected HSBContext(ILogger<HSBContext> logger)
+    /// <param name="loggerFactory"></param>
+    protected HSBContext(ILoggerFactory loggerFactory)
     {
-        _logger = logger;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<HSBContext>();
         this.ChangeTracker.LazyLoadingEnabled = false;
     }
 
@@ -55,11 +55,16 @@ public class HSBContext : DbContext
     /// <param name="options"></param>
     /// <param name="httpContextAccessor"></param>
     /// <param name="serializerOptions"></param>
-    /// <param name="logger"></param>
-    public HSBContext(DbContextOptions<HSBContext> options, IHttpContextAccessor? httpContextAccessor = null, IOptions<JsonSerializerOptions>? serializerOptions = null, ILogger<HSBContext>? logger = null)
+    /// <param name="loggerFactory"></param>
+    public HSBContext(
+        DbContextOptions<HSBContext> options,
+        IHttpContextAccessor? httpContextAccessor = null,
+        IOptions<JsonSerializerOptions>? serializerOptions = null,
+        ILoggerFactory? loggerFactory = null)
       : base(options)
     {
-        _logger = logger;
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory?.CreateLogger<HSBContext>();
         _httpContextAccessor = httpContextAccessor;
         _serializerOptions = serializerOptions?.Value;
         this.ChangeTracker.LazyLoadingEnabled = false;
@@ -74,11 +79,6 @@ public class HSBContext : DbContext
     /// <param name="optionsBuilder"></param>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        if (!optionsBuilder.IsConfigured)
-        {
-            optionsBuilder.EnableSensitiveDataLogging();
-        }
-
         base.OnConfiguring(optionsBuilder);
     }
 
@@ -89,7 +89,6 @@ public class HSBContext : DbContext
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         base.ConfigureConventions(configurationBuilder);
-        // configurationBuilder.Conventions.Remove(typeof(PluralizingTableNameConvention));
     }
 
     /// <summary>

--- a/src/libs/dal/Services/FileSystemHistoryItemService.cs
+++ b/src/libs/dal/Services/FileSystemHistoryItemService.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Security.Claims;
 using HSB.DAL.Extensions;
 using HSB.Entities;
@@ -34,6 +33,7 @@ public class FileSystemHistoryItemService : BaseService<FileSystemHistoryItem>, 
 
         return query
             .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -64,6 +64,7 @@ public class FileSystemHistoryItemService : BaseService<FileSystemHistoryItem>, 
 
         return query
             .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 

--- a/src/libs/dal/Services/FileSystemItemService.cs
+++ b/src/libs/dal/Services/FileSystemItemService.cs
@@ -35,6 +35,7 @@ public class FileSystemItemService : BaseService<FileSystemItem>, IFileSystemIte
 
         return query
             .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 
@@ -65,6 +66,7 @@ public class FileSystemItemService : BaseService<FileSystemItem>, IFileSystemIte
 
         return query
             .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 
@@ -76,7 +78,9 @@ public class FileSystemItemService : BaseService<FileSystemItem>, IFileSystemIte
                 join usert in this.Context.UserTenants on tenant.Id equals usert.TenantId
                 where usert.UserId == userId
                    && fsi.ServiceNowKey == key
-                select fsi).FirstOrDefault();
+                select fsi)
+                    .AsSplitQuery()
+                    .FirstOrDefault();
     }
 
     /// <summary>

--- a/src/libs/dal/Services/GroupService.cs
+++ b/src/libs/dal/Services/GroupService.cs
@@ -19,6 +19,7 @@ public class GroupService : BaseService<Group>, IGroupService
     {
         return this.Context.Groups
             .Include(m => m.RolesManyToMany).ThenInclude(m => m.Role)
+            .AsSingleQuery()
             .FirstOrDefault(g => g.Id == id);
     }
     #endregion

--- a/src/libs/dal/Services/IServerItemService.cs
+++ b/src/libs/dal/Services/IServerItemService.cs
@@ -1,4 +1,5 @@
 using HSB.Entities;
+using HSB.Models;
 using HSB.Models.Filters;
 
 namespace HSB.DAL.Services;
@@ -9,5 +10,11 @@ public interface IServerItemService : IBaseService<ServerItem>
 
     IEnumerable<ServerItem> FindForUser(long userId, ServerItemFilter filter);
 
-    ServerItem? FindForId(string key, long userId);
+    ServerItem? FindForId(string key, bool includeFileSystemItems = false);
+
+    ServerItem? FindForId(string key, long userId, bool includeFileSystemItems = false);
+
+    IEnumerable<ServerItemSmallModel> FindSimple(ServerItemFilter filter);
+
+    IEnumerable<ServerItemSmallModel> FindSimpleForUser(long userId, ServerItemFilter filter);
 }

--- a/src/libs/dal/Services/OperatingSystemItemService.cs
+++ b/src/libs/dal/Services/OperatingSystemItemService.cs
@@ -35,6 +35,8 @@ public class OperatingSystemItemService : BaseService<OperatingSystemItem>, IOpe
                      where userTenants.Contains(si.TenantId!.Value) || userOrganizationQuery.Contains(si.OrganizationId)
                      select osi)
             .Where(predicate)
+            .AsNoTracking()
+            .AsSplitQuery()
             .Distinct();
 
         if (sort != null)
@@ -45,7 +47,6 @@ public class OperatingSystemItemService : BaseService<OperatingSystemItem>, IOpe
             query = query.Skip(skip.Value);
 
         return query
-            .AsNoTracking()
             .ToArray();
     }
 
@@ -79,6 +80,7 @@ public class OperatingSystemItemService : BaseService<OperatingSystemItem>, IOpe
 
         return query
             .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
     #endregion

--- a/src/libs/dal/Services/OrganizationService.cs
+++ b/src/libs/dal/Services/OrganizationService.cs
@@ -36,6 +36,7 @@ public class OrganizationService : BaseService<Organization>, IOrganizationServi
 
         return query
             .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -67,6 +68,7 @@ public class OrganizationService : BaseService<Organization>, IOrganizationServi
 
         return query
             .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 

--- a/src/libs/dal/Services/ServerHistoryItemService.cs
+++ b/src/libs/dal/Services/ServerHistoryItemService.cs
@@ -21,7 +21,6 @@ public class ServerHistoryItemService : BaseService<ServerHistoryItem>, IServerH
     public IEnumerable<ServerHistoryItem> Find(ServerHistoryItemFilter filter)
     {
         var query = this.Context.ServerHistoryItems
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -34,6 +33,8 @@ public class ServerHistoryItemService : BaseService<ServerHistoryItem>, IServerH
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -49,7 +50,6 @@ public class ServerHistoryItemService : BaseService<ServerHistoryItem>, IServerH
         var query = (from si in this.Context.ServerHistoryItems
                      where userTenants.Contains(si.TenantId!.Value) || userOrganizationQuery.Contains(si.OrganizationId)
                      select si)
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -62,6 +62,8 @@ public class ServerHistoryItemService : BaseService<ServerHistoryItem>, IServerH
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 

--- a/src/libs/dal/Services/ServerItemService.cs
+++ b/src/libs/dal/Services/ServerItemService.cs
@@ -23,7 +23,6 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
     public IEnumerable<ServerItem> Find(ServerItemFilter filter)
     {
         var query = this.Context.ServerItems
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -36,6 +35,8 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -51,7 +52,6 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
         var query = (from si in this.Context.ServerItems
                      where userTenants.Contains(si.TenantId!.Value) || userOrganizationQuery.Contains(si.OrganizationId)
                      select si)
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -64,13 +64,14 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSplitQuery()
             .ToArray();
     }
 
     public IEnumerable<ServerItemSmallModel> FindSimple(ServerItemFilter filter)
     {
         var query = this.Context.ServerItems
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -83,6 +84,8 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSplitQuery()
             .Select(si => new ServerItemSmallModel(si))
             .ToArray();
     }
@@ -99,7 +102,6 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
         var query = (from si in this.Context.ServerItems
                      where userTenants.Contains(si.TenantId!.Value) || userOrganizationQuery.Contains(si.OrganizationId)
                      select si)
-            .AsNoTracking()
             .Where(filter.GeneratePredicate())
             .Distinct();
 
@@ -112,6 +114,8 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
             query = query.Skip(filter.Page.Value * filter.Quantity.Value);
 
         return query
+            .AsNoTracking()
+            .AsSplitQuery()
             .Select(si => new ServerItemSmallModel(si))
             .ToArray();
     }
@@ -126,7 +130,9 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
         if (includeFileSystemItems)
             query = query.Include(m => m.FileSystemItems);
 
-        return query.FirstOrDefault();
+        return query
+            .AsSingleQuery()
+            .FirstOrDefault();
     }
 
     public ServerItem? FindForId(string key, long userId, bool includeFileSystemItems = false)
@@ -141,7 +147,9 @@ public class ServerItemService : BaseService<ServerItem>, IServerItemService
         if (includeFileSystemItems)
             query = query.Include(m => m.FileSystemItems);
 
-        return query.FirstOrDefault();
+        return query
+            .AsSingleQuery()
+            .FirstOrDefault();
     }
 
     public override EntityEntry<ServerItem> Add(ServerItem entity)

--- a/src/libs/dal/Services/TenantService.cs
+++ b/src/libs/dal/Services/TenantService.cs
@@ -40,6 +40,7 @@ public class TenantService : BaseService<Tenant>, ITenantService
 
         return query
             .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -65,6 +66,7 @@ public class TenantService : BaseService<Tenant>, ITenantService
 
         return query
             .AsNoTracking()
+            .AsSingleQuery()
             .ToArray();
     }
 

--- a/src/libs/dal/Services/UserService.cs
+++ b/src/libs/dal/Services/UserService.cs
@@ -48,6 +48,7 @@ public class UserService : BaseService<User>, IUserService
         return this.Context.Users
             .Include(u => u.Groups).ThenInclude(g => g.Roles)
             .Where(u => EF.Functions.Like(u.Email, email))
+            .AsSingleQuery()
             .ToArray();
     }
 
@@ -55,6 +56,7 @@ public class UserService : BaseService<User>, IUserService
     {
         return this.Context.Users
             .Include(u => u.Groups).ThenInclude(g => g.Roles)
+            .AsSingleQuery()
             .FirstOrDefault(u => u.Key == key);
     }
 
@@ -62,6 +64,7 @@ public class UserService : BaseService<User>, IUserService
     {
         return this.Context.Users
             .Include(u => u.Groups).ThenInclude(g => g.Roles)
+            .AsSingleQuery()
             .FirstOrDefault(u => EF.Functions.Like(u.Username, username));
     }
 

--- a/src/libs/models/ServerItemSmallModel.cs
+++ b/src/libs/models/ServerItemSmallModel.cs
@@ -1,9 +1,8 @@
-﻿using System.Text.Json;
-using HSB.Entities;
+﻿using HSB.Entities;
 using System.Text.Json.Serialization;
 
 namespace HSB.Models;
-public class ServerItemModel : AuditableModel
+public class ServerItemSmallModel
 {
     #region Properties
     public string ServiceNowKey { get; set; } = "";
@@ -15,11 +14,7 @@ public class ServerItemModel : AuditableModel
     public int? OperatingSystemItemId { get; set; }
     public OperatingSystemItemModel? OperatingSystem { get; set; }
 
-    public IEnumerable<FileSystemItemModel> FileSystemItems { get; set; } = Array.Empty<FileSystemItemModel>();
-
     #region ServiceNow Properties
-    public JsonDocument RawData { get; set; } = JsonDocument.Parse("{}");
-    public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
     public string Category { get; set; } = "";
@@ -42,18 +37,15 @@ public class ServerItemModel : AuditableModel
     #endregion
 
     #region Constructors
-    public ServerItemModel() { }
+    public ServerItemSmallModel() { }
 
-    public ServerItemModel(ServerItem entity) : base(entity)
+    public ServerItemSmallModel(ServerItem entity)
     {
         this.ServiceNowKey = entity.ServiceNowKey;
 
         this.TenantId = entity.TenantId;
         this.OrganizationId = entity.OrganizationId;
         this.OperatingSystemItemId = entity.OperatingSystemItemId;
-
-        this.RawData = entity.RawData;
-        this.RawDataCI = entity.RawDataCI;
 
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
@@ -67,11 +59,9 @@ public class ServerItemModel : AuditableModel
 
         this.Capacity = entity.Capacity;
         this.AvailableSpace = entity.AvailableSpace;
-
-        this.FileSystemItems = entity.FileSystemItems.Select(fsi => new FileSystemItemModel(fsi)).ToArray();
     }
 
-    public ServerItemModel(
+    public ServerItemSmallModel(
         int? tenantId,
         int organizationId,
         int? operatingSystemItemId,
@@ -87,9 +77,6 @@ public class ServerItemModel : AuditableModel
         this.OrganizationId = organizationId;
         this.OperatingSystemItemId = operatingSystemItemId;
 
-        this.RawData = serverModel.RawData;
-        this.RawDataCI = ciModel.RawData;
-
         this.ClassName = serverModel.Data.ClassName ?? "";
         this.Name = serverModel.Data.Name ?? "";
         this.Category = serverModel.Data.Category ?? "";
@@ -99,39 +86,6 @@ public class ServerItemModel : AuditableModel
         this.IPAddress = serverModel.Data.IPAddress ?? "";
         this.FQDN = serverModel.Data.FQDN ?? "";
         this.DiskSpace = !String.IsNullOrWhiteSpace(serverModel.Data.DiskSpace) ? float.Parse(serverModel.Data.DiskSpace) : null;
-    }
-    #endregion
-
-    #region Methods
-    public ServerItem ToEntity()
-    {
-        return (ServerItem)this;
-    }
-
-    public static explicit operator ServerItem(ServerItemModel model)
-    {
-        if (model.RawData == null) throw new InvalidOperationException("Property 'RawData' is required.");
-
-        return new ServerItem(model.TenantId, model.OrganizationId, model.OperatingSystemItemId, model.RawData, model.RawDataCI)
-        {
-            ServiceNowKey = model.ServiceNowKey,
-            ClassName = model.ClassName,
-            Name = model.Name,
-            Category = model.Category,
-            Subcategory = model.Subcategory,
-            DnsDomain = model.DnsDomain,
-            Platform = model.Platform,
-            IPAddress = model.IPAddress,
-            FQDN = model.FQDN,
-            DiskSpace = model.DiskSpace,
-            Capacity = model.Capacity,
-            AvailableSpace = model.AvailableSpace,
-            CreatedOn = model.CreatedOn,
-            CreatedBy = model.CreatedBy,
-            UpdatedOn = model.UpdatedOn,
-            UpdatedBy = model.UpdatedBy,
-            Version = model.Version,
-        };
     }
     #endregion
 }


### PR DESCRIPTION
The filter will now apply URL query string parameters so that the back/forward button history is maintained.  The back/forward buttons will update the filter selections, but do not currently update the dashboard (I was running into ugly loops if I added that feature too).  We'll test to see if this is good enough.

- Improving performance (very slight)
- Hook up URL parameters
- Hooked up All Server page links to return to dashboard