### PR TITLE
HOSTSD-288 - UI: add new users for hsb/admin/users page

### DIFF
--- a/src/dashboard/src/app/hsb/admin/users/Users.module.scss
+++ b/src/dashboard/src/app/hsb/admin/users/Users.module.scss
@@ -96,7 +96,8 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid $medium-gray;
-  padding: 0 .5rem;
+  padding: 0.5rem;
+  gap: 1rem;
 
   &:hover {
     background-color: rgba($light-gray, 0.4);
@@ -104,5 +105,11 @@
   
   div {
     flex: 1;
+  }
+
+  input {
+    width: 100%;
+    max-width: 200px;
+    margin: 0;
   }
 }

--- a/src/dashboard/src/app/hsb/admin/users/Users.module.scss
+++ b/src/dashboard/src/app/hsb/admin/users/Users.module.scss
@@ -70,3 +70,39 @@
     flex: 1.5;
   }
 }
+
+.newRow {
+  background-color: $light-gray;
+  color: $info-gray;
+  font-weight: bold;
+  font-size: $font-size-small;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 16px;
+  border-bottom: 1px solid $medium-gray;
+  cursor: pointer;
+
+  &:hover {
+    color: $bc-black;
+  }
+
+  span {
+    font-size: $font-size-medium;
+  }
+}
+
+.addNewRow {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid $medium-gray;
+  padding: 0 .5rem;
+
+  &:hover {
+    background-color: rgba($light-gray, 0.4);
+  }
+  
+  div {
+    flex: 1;
+  }
+}

--- a/src/dashboard/src/app/hsb/admin/users/page.tsx
+++ b/src/dashboard/src/app/hsb/admin/users/page.tsx
@@ -25,11 +25,18 @@ export default function Page() {
   const [filteredUsers, setFilteredUsers] = React.useState<number[]>([]);
   const [filter, setFilter] = React.useState('');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [newRows, setNewRows] = React.useState<React.ReactNode[]>([]);
 
   const dialogRef = React.useRef<HTMLDialogElement>(null);
   const [dialog, setDialog] = React.useState<{ user: IUserForm; variant: UserDialogVariant }>();
 
   const isDirty = formUsers.some((u) => u.isDirty);
+
+  const handleAddNewRow = () => {
+    const newRowKey = `newRow-${newRows.length}`;
+    const newRowElement = <AddNewRow key={newRowKey} />;
+    setNewRows([newRowElement, ...newRows]);
+  };  
 
   React.useEffect(() => {
     setLoading(!isReadyUsers && !isReadyGroups);
@@ -149,6 +156,14 @@ export default function Page() {
                 <div>Roles, Tenants, Organizations</div>
               </>
             }
+            addNew={
+              <>
+              <div className={styles.newRow} onClick={handleAddNewRow}>
+                <span>+</span> Add new user
+              </div>
+                {newRows.map(newRow => newRow)}
+              </>
+            }
           >
             {({ data }) => {
               return (
@@ -219,3 +234,42 @@ export default function Page() {
     </Sheet>
   );
 }
+
+const AddNewRow = () => {
+  return (
+    <div className={styles.addNewRow}>
+    <div><Text placeholder="Username" /></div>
+    <div><Text placeholder="Email" /></div>
+    <div><Text placeholder="Name" /></div>
+    <div className={styles.checkbox}><Checkbox /></div>
+    <div className={styles.selectRow}>
+      <div>
+        <p>
+          <span>Roles: </span>
+        </p>
+        <Button variant="secondary">
+          Edit
+        </Button>
+      </div>
+      <div>
+        <p>
+          <span>Organizations: </span>
+        </p>
+        <Button
+          variant="secondary"
+        >
+          Edit
+        </Button>
+      </div>
+      <div>
+        <p>
+          <span>Tenant: </span>
+        </p>
+        <Button variant="secondary">
+          Edit
+        </Button>
+      </div>
+    </div>
+  </div>
+  );
+};

--- a/src/dashboard/src/components/table/ITableAddNewProps.ts
+++ b/src/dashboard/src/components/table/ITableAddNewProps.ts
@@ -1,0 +1,3 @@
+export interface ITableAddNewProps<T extends object> {
+  data: T[];
+}

--- a/src/dashboard/src/components/table/Table.module.scss
+++ b/src/dashboard/src/components/table/Table.module.scss
@@ -3,7 +3,6 @@
 .table {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
 
   .tableHeader {
     display: flex;

--- a/src/dashboard/src/components/table/Table.module.scss
+++ b/src/dashboard/src/components/table/Table.module.scss
@@ -19,33 +19,31 @@
   }
 
   .tableRows {
-    padding: 0 1rem;
     max-height: 450px;
     overflow-y: scroll;
     @include scrollBar;
     border-bottom: solid 1px $medium-gray;
+  }
 
-    .tableRow {
-      position: relative;
-      display: flex;
-      flex-direction: row;
-      gap: 1rem;
-      min-height: 60px;
-      padding: 0.5rem;
-      border-bottom: solid 1px $medium-gray;
-      align-items: center;
-      position: relative;
+  .tableRow {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    min-height: 60px;
+    padding: 0.5rem;
+    border-bottom: solid 1px $medium-gray;
+    align-items: center;
+    position: relative;
 
-      &:hover {
-        background-color: $light-gray;
-      }
-
-      >div:not(.loadingAnimation) {
-        flex: 1;
-        position: relative;
-      }
+    &:hover {
+      background-color: $light-gray;
     }
 
+    >div:not(.loadingAnimation) {
+      flex: 1;
+      position: relative;
+    }
   }
 
   .tableFooter {

--- a/src/dashboard/src/components/table/Table.tsx
+++ b/src/dashboard/src/components/table/Table.tsx
@@ -1,6 +1,7 @@
 import { LoadingAnimation } from '..';
 import { ITableFooterProps } from './ITableFooterProps';
 import { ITableHeaderProps } from './ITableHeaderProps';
+import { ITableAddNewProps } from './ITableAddNewProps';
 import { ITableRowProps } from './ITableRowProps';
 import styles from './Table.module.scss';
 
@@ -9,7 +10,9 @@ export interface ITableProps<T extends object> {
   rows?: ITableRowProps<T>[];
   rowKey?: keyof T | ((data: T, index: number) => React.Key | null | undefined);
   showHeader?: boolean;
+  showAddNew?: boolean;
   header?: React.ReactNode | ((props: ITableHeaderProps<T>) => React.ReactNode);
+  addNew?: React.ReactNode | ((props: ITableAddNewProps<T>) => React.ReactNode);
   children?: React.ReactNode | ((props: ITableRowProps<T>) => React.ReactNode);
   showFooter?: boolean;
   footer?: React.ReactNode | ((props: ITableFooterProps<T>) => React.ReactNode);
@@ -19,7 +22,9 @@ export const Table = <T extends object>({
   data,
   rows: initRows,
   showHeader = true,
+  showAddNew = true,
   header,
+  addNew,
   rowKey = (_, index) => index,
   children,
   showFooter,
@@ -42,6 +47,16 @@ export const Table = <T extends object>({
         </div>
       )}
       <div className={styles.tableRows}>
+        {showAddNew && (
+          <>
+            {typeof addNew === 'function'
+            ? (addNew as (props: ITableAddNewProps<T>) => React.ReactNode)({
+                data: rows.map((r) => r.data),
+              })
+            : addNew}
+          </>
+        )}
+        
         {rows.map((row, index) => {
           return (
             <div


### PR DESCRIPTION
Adding ability to add rows to the table on hsb/admin/users page so that users can input information to add new users.
Added new 'addNew' section to the table component by copying how the table 'header' is conditionally added.
Functionality to add info to new users is still needed, including functionality for the popups for Role, Tenant, and Organization.