### PR TITLE
No ticket - hiding excel button for all charts

### DIFF
--- a/src/dashboard/src/styles/_globals.scss
+++ b/src/dashboard/src/styles/_globals.scss
@@ -48,6 +48,7 @@
   padding: 5px;
   padding-left: 28px;
   font-size: $font-size-small;
+  display: none;
 
   img {
     left: 9px;


### PR DESCRIPTION
Hiding export to excel button for all charts on dashboard so users can focus more on dashboard functionality and usage.
Can be unhidden at any time.