### PR TITLE
HOSTSD-292 Fix Organization Admin

### DIFF
--- a/src/dashboard/src/app/client/admin/users/page.tsx
+++ b/src/dashboard/src/app/client/admin/users/page.tsx
@@ -77,7 +77,6 @@ export default function Page() {
       }),
     );
     setFilteredUsers(searchUsers(users, filter).map((u) => u.id));
-    setOrganization('Example Organization');
     // Only apply the 'filter' when the button is pressed.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [users]);

--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -74,6 +74,8 @@ export const Dashboard = () => {
 
   const updateDashboard = useDashboardFilter();
 
+  const [init, setInit] = React.useState(true);
+
   // Total storage is for a single organization
   const showTotalStorage =
     !!dashboardServerItem || (!!dashboardOrganization && !dashboardOperatingSystemItem);
@@ -96,17 +98,24 @@ export const Dashboard = () => {
     // When no filter is selected use all values available.
     if (
       isReadyTenants &&
-      !values.tenant &&
       isReadyOrganizations &&
-      !values.organization &&
       isReadyOperatingSystemItems &&
-      !values.operatingSystemItem &&
-      isReadyServerItems &&
-      !values.serverItem
+      isReadyServerItems
     ) {
-      updateDashboard({ reset: true });
+      if (
+        !values.tenant &&
+        !values.organization &&
+        !values.operatingSystemItem &&
+        !values.serverItem
+      ) {
+        updateDashboard({ reset: true });
+      } else if (init) {
+        updateDashboard({ applyFilter: true });
+      }
+      setInit(false);
     }
   }, [
+    init,
     isReadyOperatingSystemItems,
     isReadyOrganizations,
     isReadyServerItems,

--- a/src/dashboard/src/components/filter/Filter.tsx
+++ b/src/dashboard/src/components/filter/Filter.tsx
@@ -136,12 +136,26 @@ export const Filter: React.FC = () => {
       <button
         className={styles.reset}
         onClick={async () => {
-          setValues(() => ({}));
+          const tenant = tenants.length === 1 ? tenants[0] : undefined;
+          const organization = organizations.length === 1 ? organizations[0] : undefined;
+          const operatingSystemItem =
+            operatingSystemItems.length === 1 ? operatingSystemItems[0] : undefined;
+          const serverItem = serverItems.length === 1 ? serverItems[0] : undefined;
+          setValues(() => ({ tenant, organization, operatingSystemItem, serverItem }));
           setFilteredTenants(tenants);
           setFilteredOrganizations(organizations);
           setFilteredOperatingSystemItems(operatingSystemItems);
           setFilteredServerItems(serverItems);
-          await updateDashboard({ reset: true });
+          await updateDashboard({
+            tenant,
+            organization,
+            operatingSystemItem,
+            serverItem,
+            tenants,
+            organizations,
+            operatingSystemItems,
+            serverItems,
+          });
         }}
       >
         Reset Filters


### PR DESCRIPTION
Fixing issues in the Client Organization Admin page for user management.  An Organization Admin will only be able to add/remove the `organization-admin` role, and tenants and organizations they belong to.

## Organization Admin Users Page

![image](https://github.com/bcgov/hsb-dashboard/assets/3180256/e8f70fb3-104f-46fb-a27c-ce8727487505)
