### PR TITLE
HOSTSD-246 Improve Data Service

### DIFF
--- a/src/data-service/Helpers/HsbApiService.cs
+++ b/src/data-service/Helpers/HsbApiService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using HSB.Core.Http;
 using System.Net.Http.Json;
+using HSB.Core.Extensions;
 
 namespace HSB.DataService;
 
@@ -290,13 +291,15 @@ public class HsbApiService : IHsbApiService
     /// <summary>
     /// Fetch all server items from HSB.
     /// </summary>
+    /// <param name="filter"></param>
     /// <returns></returns>
-    public async Task<IEnumerable<ServerItemModel>> FetchServerItemsAsync()
+    public async Task<IEnumerable<ServerItemModel>> FetchServerItemsAsync(Models.Filters.ServerItemFilter? filter = null)
     {
         this.Logger.LogDebug("HSB - Fetching all server items");
         var builder = new UriBuilder($"{this.ApiClient.Client.BaseAddress}")
         {
-            Path = this.Options.Endpoints.ServerItems
+            Path = this.Options.Endpoints.ServerItems,
+            Query = filter?.GetQueryString() ?? "",
         };
         var results = await HsbSendAsync<IEnumerable<ServerItemModel>>(HttpMethod.Get, builder.Uri);
         return results ?? Array.Empty<ServerItemModel>();
@@ -332,6 +335,22 @@ public class HsbApiService : IHsbApiService
         };
         var results = await HsbSendAsync<ServerItemModel>(HttpMethod.Put, builder.Uri, JsonContent.Create(model));
         return results;
+    }
+
+    /// <summary>
+    /// Delete server item in HSB.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    public async Task<ServerItemModel> DeleteServerItemAsync(ServerItemModel model)
+    {
+        this.Logger.LogDebug("HSB - Delete server item");
+        var builder = new UriBuilder($"{this.ApiClient.Client.BaseAddress}")
+        {
+            Path = $"{this.Options.Endpoints.ServerItems}/{model.ServiceNowKey}"
+        };
+        var results = await HsbSendAsync<ServerItemModel>(HttpMethod.Delete, builder.Uri, JsonContent.Create(model));
+        return results ?? model;
     }
     #endregion
 

--- a/src/data-service/Helpers/IHsbApiService.cs
+++ b/src/data-service/Helpers/IHsbApiService.cs
@@ -12,21 +12,21 @@ public interface IHsbApiService
     /// Fetch all data sync configuration items.
     /// </summary>
     /// <returns></returns>
-    public Task<IEnumerable<DataSyncModel>> FetchDataSyncAsync();
+    Task<IEnumerable<DataSyncModel>> FetchDataSyncAsync();
 
     /// <summary>
     /// Get the data sync for the specified name.
     /// </summary>
     /// <param name="name"></param>
     /// <returns></returns>
-    public Task<DataSyncModel?> GetDataSyncAsync(string name);
+    Task<DataSyncModel?> GetDataSyncAsync(string name);
 
     /// <summary>
     /// Update the data sync.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<DataSyncModel?> UpdateDataSyncAsync(DataSyncModel model);
+    Task<DataSyncModel?> UpdateDataSyncAsync(DataSyncModel model);
     #endregion
 
     #region Operating System Items
@@ -34,21 +34,21 @@ public interface IHsbApiService
     /// Fetch all operating system items from HSB.
     /// </summary>
     /// <returns></returns>
-    public Task<IEnumerable<OperatingSystemItemModel>> FetchOperatingSystemItemsAsync();
+    Task<IEnumerable<OperatingSystemItemModel>> FetchOperatingSystemItemsAsync();
 
     /// <summary>
     /// Add operating system to HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<OperatingSystemItemModel?> AddOperatingSystemItemAsync(OperatingSystemItemModel model);
+    Task<OperatingSystemItemModel?> AddOperatingSystemItemAsync(OperatingSystemItemModel model);
 
     /// <summary>
     /// Update operating system in HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<OperatingSystemItemModel?> UpdateOperatingSystemItemAsync(OperatingSystemItemModel model);
+    Task<OperatingSystemItemModel?> UpdateOperatingSystemItemAsync(OperatingSystemItemModel model);
     #endregion
 
     #region Tenants
@@ -56,21 +56,21 @@ public interface IHsbApiService
     /// Fetch all tenants from HSB.
     /// </summary>
     /// <returns></returns>
-    public Task<IEnumerable<TenantModel>> FetchTenantsAsync();
+    Task<IEnumerable<TenantModel>> FetchTenantsAsync();
 
     /// <summary>
     /// Add tenant to HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<TenantModel?> AddTenantAsync(TenantModel model);
+    Task<TenantModel?> AddTenantAsync(TenantModel model);
 
     /// <summary>
     /// Update tenant in HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<TenantModel?> UpdateTenantAsync(TenantModel model);
+    Task<TenantModel?> UpdateTenantAsync(TenantModel model);
     #endregion
 
     #region Organizations
@@ -78,43 +78,51 @@ public interface IHsbApiService
     /// Fetch all organizations from HSB.
     /// </summary>
     /// <returns></returns>
-    public Task<IEnumerable<OrganizationModel>> FetchOrganizationsAsync();
+    Task<IEnumerable<OrganizationModel>> FetchOrganizationsAsync();
 
     /// <summary>
     /// Add organization to HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<OrganizationModel?> AddOrganizationAsync(OrganizationModel model);
+    Task<OrganizationModel?> AddOrganizationAsync(OrganizationModel model);
 
     /// <summary>
     /// Update organization in HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<OrganizationModel?> UpdateOrganizationAsync(OrganizationModel model);
+    Task<OrganizationModel?> UpdateOrganizationAsync(OrganizationModel model);
     #endregion
 
     #region Servers
     /// <summary>
     /// Fetch all server items from HSB.
     /// </summary>
+    /// <param name="filter"></param>
     /// <returns></returns>
-    public Task<IEnumerable<ServerItemModel>> FetchServerItemsAsync();
+    Task<IEnumerable<ServerItemModel>> FetchServerItemsAsync(Models.Filters.ServerItemFilter? filter = null);
 
     /// <summary>
     /// Add server item to HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<ServerItemModel?> AddServerItemAsync(ServerItemModel model);
+    Task<ServerItemModel?> AddServerItemAsync(ServerItemModel model);
 
     /// <summary>
     /// Update server item in HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<ServerItemModel?> UpdateServerItemAsync(ServerItemModel model);
+    Task<ServerItemModel?> UpdateServerItemAsync(ServerItemModel model);
+
+    /// <summary>
+    /// Delete server item in HSB.
+    /// </summary>
+    /// <param name="model"></param>
+    /// <returns></returns>
+    Task<ServerItemModel> DeleteServerItemAsync(ServerItemModel model);
     #endregion
 
     #region File System Items
@@ -122,27 +130,27 @@ public interface IHsbApiService
     /// Fetch all file system items from HSB.
     /// </summary>
     /// <returns></returns>
-    public Task<IEnumerable<FileSystemItemModel>> FetchFileSystemItemsAsync();
+    Task<IEnumerable<FileSystemItemModel>> FetchFileSystemItemsAsync();
 
     /// <summary>
-    /// Get the file system item from HSB for the specified 'id'.
+    ///Get the file system item from HSB for the specified 'id'.
     /// </summary>
     /// <param name="id"></param>
     /// <returns></returns>
-    public Task<FileSystemItemModel?> GetFileSystemItemAsync(string id);
+    Task<FileSystemItemModel?> GetFileSystemItemAsync(string id);
 
     /// <summary>
     /// Add file system item to HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<FileSystemItemModel?> AddFileSystemItemAsync(FileSystemItemModel model);
+    Task<FileSystemItemModel?> AddFileSystemItemAsync(FileSystemItemModel model);
 
     /// <summary>
     /// Update file system item in HSB.
     /// </summary>
     /// <param name="model"></param>
     /// <returns></returns>
-    public Task<FileSystemItemModel?> UpdateFileSystemItemAsync(FileSystemItemModel model);
+    Task<FileSystemItemModel?> UpdateFileSystemItemAsync(FileSystemItemModel model);
     #endregion
 }

--- a/src/libs/core/Extensions/ObjectExtensions.cs
+++ b/src/libs/core/Extensions/ObjectExtensions.cs
@@ -1,3 +1,5 @@
+using System.Web;
+
 namespace HSB.Core.Extensions
 {
     /// <summary>
@@ -49,6 +51,20 @@ namespace HSB.Core.Extensions
             }
 
             return Convert.ChangeType(value, t);
+        }
+
+        /// <summary>
+        /// Convert object into a query string parameter list.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public static string GetQueryString(this object obj)
+        {
+            var properties = from p in obj.GetType().GetProperties()
+                             where p.GetValue(obj, null) != null && (p.GetValue(obj, null)?.GetType().IsArray == false || ((Array?)p.GetValue(obj, null))?.Length > 0)
+                             select p.Name + "=" + HttpUtility.UrlEncode(p.GetValue(obj, null)?.ToString());
+
+            return String.Join("&", properties.ToArray());
         }
         #endregion
     }

--- a/src/libs/dal/Configuration/FileSystemHistoryItemConfiguration.cs
+++ b/src/libs/dal/Configuration/FileSystemHistoryItemConfiguration.cs
@@ -20,6 +20,7 @@ public class FileSystemHistoryItemConfiguration : AuditableConfiguration<FileSys
         builder.Property(m => m.ServerItemServiceNowKey).IsRequired().HasMaxLength(100);
         builder.Property(m => m.ClassName).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
         builder.Property(m => m.Name).IsRequired().HasMaxLength(200);
+        builder.Property(m => m.InstallStatus).IsRequired();
         builder.Property(m => m.Label).IsRequired().HasMaxLength(100);
         builder.Property(m => m.Category).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
         builder.Property(m => m.Subcategory).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
@@ -38,7 +39,7 @@ public class FileSystemHistoryItemConfiguration : AuditableConfiguration<FileSys
         builder.HasOne(m => m.FileSystemItem).WithMany(m => m.History).HasForeignKey(m => m.ServiceNowKey).OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(m => new { m.CreatedOn }, "IX_FileSystemHistoryItem_CreatedOn");
-        builder.HasIndex(m => new { m.ServiceNowKey, m.ServerItemServiceNowKey }, "IX_FileSystemHistoryItem_ServiceNowKey_ServerItemServiceNowKey");
+        builder.HasIndex(m => new { m.InstallStatus, m.ServiceNowKey, m.ServerItemServiceNowKey }, "IX_FileSystemHistoryItem_InstallStatus_ServiceNowKey_ServerItemServiceNowKey");
 
         base.Configure(builder);
     }

--- a/src/libs/dal/Configuration/FileSystemItemConfiguration.cs
+++ b/src/libs/dal/Configuration/FileSystemItemConfiguration.cs
@@ -19,6 +19,7 @@ public class FileSystemConfiguration : AuditableConfiguration<FileSystemItem>
         builder.Property(m => m.ServerItemServiceNowKey).IsRequired().HasMaxLength(100);
         builder.Property(m => m.ClassName).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
         builder.Property(m => m.Name).IsRequired().HasMaxLength(200);
+        builder.Property(m => m.InstallStatus).IsRequired();
         builder.Property(m => m.Label).IsRequired().HasMaxLength(100);
         builder.Property(m => m.Category).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
         builder.Property(m => m.Subcategory).IsRequired().HasMaxLength(100).HasDefaultValueSql("''");
@@ -36,7 +37,7 @@ public class FileSystemConfiguration : AuditableConfiguration<FileSystemItem>
 
         builder.HasOne(m => m.ServerItem).WithMany(m => m.FileSystemItems).HasForeignKey(m => m.ServerItemServiceNowKey).OnDelete(DeleteBehavior.Cascade);
 
-        builder.HasIndex(m => new { m.Name, m.ServerItemServiceNowKey }, "IX_FileSystemItem_Name_ServerItemServiceNowKey");
+        builder.HasIndex(m => new { m.InstallStatus, m.ServerItemServiceNowKey }, "IX_FileSystemItem_InstallStatus_ServerItemServiceNowKey");
 
         base.Configure(builder);
     }

--- a/src/libs/dal/Configuration/ServerHistoryItemConfiguration.cs
+++ b/src/libs/dal/Configuration/ServerHistoryItemConfiguration.cs
@@ -16,6 +16,7 @@ public class ServerHistoryItemConfiguration : AuditableConfiguration<ServerHisto
         builder.Property(m => m.OrganizationId);
         builder.Property(m => m.OperatingSystemItemId);
         builder.Property(m => m.HistoryKey);
+        builder.Property(m => m.InstallStatus).IsRequired();
 
         builder.Property(m => m.RawData).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
         builder.Property(m => m.RawDataCI).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
@@ -40,7 +41,7 @@ public class ServerHistoryItemConfiguration : AuditableConfiguration<ServerHisto
         builder.HasOne(m => m.OperatingSystemItem).WithMany().HasForeignKey(m => m.OperatingSystemItemId).OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(m => new { m.CreatedOn }, "IX_ServerHistoryItem_CreatedOn");
-        builder.HasIndex(m => new { m.ServiceNowKey }, "IX_ServerHistoryItem_ServiceNowKey");
+        builder.HasIndex(m => new { m.InstallStatus, m.ServiceNowKey }, "IX_ServerHistoryItem_InstallStatus_ServiceNowKey");
         builder.HasIndex(m => new { m.HistoryKey }, "IX_ServerHistoryItem_HistoryKey");
 
         base.Configure(builder);

--- a/src/libs/dal/Configuration/ServerItemConfiguration.cs
+++ b/src/libs/dal/Configuration/ServerItemConfiguration.cs
@@ -16,6 +16,7 @@ public class ServerItemConfiguration : AuditableConfiguration<ServerItem>
         builder.Property(m => m.OrganizationId);
         builder.Property(m => m.OperatingSystemItemId);
         builder.Property(m => m.HistoryKey);
+        builder.Property(m => m.InstallStatus).IsRequired();
 
         builder.Property(m => m.RawData).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
         builder.Property(m => m.RawDataCI).IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
@@ -37,7 +38,7 @@ public class ServerItemConfiguration : AuditableConfiguration<ServerItem>
         builder.HasOne(m => m.Organization).WithMany(m => m.ServerItems).HasForeignKey(m => m.OrganizationId).OnDelete(DeleteBehavior.Cascade);
         builder.HasOne(m => m.OperatingSystemItem).WithMany(m => m.ServerItems).HasForeignKey(m => m.OperatingSystemItemId).OnDelete(DeleteBehavior.Cascade);
 
-        builder.HasIndex(m => new { m.Name }, "IX_ServerItem_Name");
+        builder.HasIndex(m => new { m.InstallStatus, m.UpdatedOn }, "IX_ServerItem_InstallStatus_UpdatedOn");
 
         base.Configure(builder);
     }

--- a/src/libs/dal/Migrations/1.0.1/Down/PostDown/00-FindFileSystemHistoryItemsByMonth.sql
+++ b/src/libs/dal/Migrations/1.0.1/Down/PostDown/00-FindFileSystemHistoryItemsByMonth.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION "FindFileSystemHistoryItemsByMonth"(
+  "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serverServiceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."FileSystemHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "ServiceNowKey"
+    , "RawData"
+    , "RawDataCI"
+    , "Name"
+    , "Label"
+    , "Category"
+    , "Subcategory"
+    , "StorageType"
+    , "MediaType"
+    , "VolumeId"
+    , "ClassName"
+    , "Capacity"
+    , "DiskSpace"
+    , "Size"
+    , "SizeBytes"
+    , "UsedSizeBytes"
+    , "AvailableSpace"
+    , "FreeSpace"
+    , "FreeSpaceBytes"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "ServerItemServiceNowKey"
+  FROM (
+    SELECT fshi.*
+      , ROW_NUMBER() OVER (PARTITION BY fshi."ServiceNowKey", EXTRACT(YEAR FROM fshi."CreatedOn"), EXTRACT(MONTH FROM fshi."CreatedOn") ORDER BY fshi."CreatedOn") AS "rn"
+    FROM public."FileSystemHistoryItem" AS fshi
+    JOIN public."FileSystemItem" AS fsi ON fshi."ServiceNowKey" = fsi."ServiceNowKey"
+    JOIN public."ServerItem" AS si ON fsi."ServerItemServiceNowKey" = si."ServiceNowKey"
+    WHERE fshi."CreatedOn" >= $1
+      AND ($2 IS NULL OR fshi."CreatedOn" <= $2)
+      AND ($3 IS NULL OR si."TenantId" = $3)
+      AND ($4 IS NULL OR si."OrganizationId" = $4)
+      AND ($5 IS NULL OR si."OperatingSystemItemId" = $5)
+      AND ($6 IS NULL OR fshi."ServerItemServiceNowKey" = $6)
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$

--- a/src/libs/dal/Migrations/1.0.1/Down/PostDown/00-FindFileSystemHistoryItemsByMonthForUser.sql
+++ b/src/libs/dal/Migrations/1.0.1/Down/PostDown/00-FindFileSystemHistoryItemsByMonthForUser.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION "FindFileSystemHistoryItemsByMonthForUser"(
+  "userId" INT
+  , "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serverServiceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."FileSystemHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "ServiceNowKey"
+    , "RawData"
+    , "RawDataCI"
+    , "Name"
+    , "Label"
+    , "Category"
+    , "Subcategory"
+    , "StorageType"
+    , "MediaType"
+    , "VolumeId"
+    , "ClassName"
+    , "Capacity"
+    , "DiskSpace"
+    , "Size"
+    , "SizeBytes"
+    , "UsedSizeBytes"
+    , "AvailableSpace"
+    , "FreeSpace"
+    , "FreeSpaceBytes"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "ServerItemServiceNowKey"
+  FROM (
+    SELECT fshi.*
+      , ROW_NUMBER() OVER (PARTITION BY fshi."ServiceNowKey", EXTRACT(YEAR FROM fshi."CreatedOn"), EXTRACT(MONTH FROM fshi."CreatedOn") ORDER BY fshi."CreatedOn") AS "rn"
+    FROM public."FileSystemHistoryItem" AS fshi
+    JOIN public."FileSystemItem" AS fsi ON fshi."ServiceNowKey" = fsi."ServiceNowKey"
+    JOIN public."ServerItem" AS si ON fsi."ServerItemServiceNowKey" = si."ServiceNowKey"
+    WHERE fshi."CreatedOn" >= $2
+      AND ($3 IS NULL OR fshi."CreatedOn" <= $3)
+      AND ($4 IS NULL OR si."TenantId" = $4)
+      AND ($5 IS NULL OR si."OrganizationId" = $5)
+      AND ($6 IS NULL OR si."OperatingSystemItemId" = $6)
+      AND ($7 IS NULL OR fshi."ServerItemServiceNowKey" = $7)
+      AND (si."TenantId" IN (SELECT "TenantId" FROM public."UserTenant" WHERE "UserId" = $1)
+        OR si."OrganizationId" IN (SELECT "OrganizationId" FROM public."UserOrganization" WHERE "UserId" = $1))
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$

--- a/src/libs/dal/Migrations/1.0.1/Down/PostDown/01-FindServerHistoryItemsByMonth.sql
+++ b/src/libs/dal/Migrations/1.0.1/Down/PostDown/01-FindServerHistoryItemsByMonth.sql
@@ -1,0 +1,55 @@
+CREATE OR REPLACE FUNCTION "FindServerHistoryItemsByMonth"(
+  "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serviceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."ServerHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "TenantId"
+    , "OrganizationId"
+    , "OperatingSystemItemId"
+    , "ServiceNowKey"
+    , "HistoryKey"
+    , "RawData"
+    , "RawDataCI"
+    , "ClassName"
+    , "Name"
+    , "Category"
+    , "Subcategory"
+    , "DnsDomain"
+    , "Platform"
+    , "IPAddress"
+    , "FQDN"
+    , "DiskSpace"
+    , "Capacity"
+    , "AvailableSpace"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+  FROM (
+    SELECT *
+      , ROW_NUMBER() OVER (PARTITION BY "ServiceNowKey", EXTRACT(YEAR FROM "CreatedOn"), EXTRACT(MONTH FROM "CreatedOn") ORDER BY "CreatedOn") AS "rn"
+    FROM public."ServerHistoryItem"
+    WHERE "CreatedOn" >= $1
+      AND ($2 IS NULL OR "CreatedOn" <= $2)
+      AND ($3 IS NULL OR "TenantId" = $3)
+      AND ($4 IS NULL OR "OrganizationId" = $4)
+      AND ($5 IS NULL OR "OperatingSystemItemId" = $5)
+      AND ($6 IS NULL OR "ServiceNowKey" = $6)
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$
+
+-- Use by calling
+-- select * from public."FindServerHistoryItemsByMonth"('2023-12-01');

--- a/src/libs/dal/Migrations/1.0.1/Down/PostDown/01-FindServerHistoryItemsByMonthForUser.sql
+++ b/src/libs/dal/Migrations/1.0.1/Down/PostDown/01-FindServerHistoryItemsByMonthForUser.sql
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION "FindServerHistoryItemsByMonthForUser"(
+  "userId" INT
+  , "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serviceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."ServerHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "TenantId"
+    , "OrganizationId"
+    , "OperatingSystemItemId"
+    , "ServiceNowKey"
+    , "HistoryKey"
+    , "RawData"
+    , "RawDataCI"
+    , "ClassName"
+    , "Name"
+    , "Category"
+    , "Subcategory"
+    , "DnsDomain"
+    , "Platform"
+    , "IPAddress"
+    , "FQDN"
+    , "DiskSpace"
+    , "Capacity"
+    , "AvailableSpace"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+  FROM (
+    SELECT shi.*
+      , ROW_NUMBER() OVER (PARTITION BY shi."ServiceNowKey", EXTRACT(YEAR FROM shi."CreatedOn"), EXTRACT(MONTH FROM shi."CreatedOn") ORDER BY shi."CreatedOn") AS "rn"
+    FROM public."ServerHistoryItem" shi
+    JOIN public."ServerItem" si ON shi."ServiceNowKey" = si."ServiceNowKey"
+    WHERE shi."CreatedOn" >= $2
+      AND ($3 IS NULL OR shi."CreatedOn" <= $3)
+      AND ($4 IS NULL OR shi."TenantId" = $4)
+      AND ($5 IS NULL OR shi."OrganizationId" = $5)
+      AND ($6 IS NULL OR shi."OperatingSystemItemId" = $6)
+      AND ($7 IS NULL OR shi."ServiceNowKey" = $7)
+      AND (si."TenantId" IN (SELECT "TenantId" FROM public."UserTenant" WHERE "UserId" = $1)
+        OR si."OrganizationId" IN (SELECT "OrganizationId" FROM public."UserOrganization" WHERE "UserId" = $1))
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$
+
+-- Use by calling
+-- select * from public."FindServerHistoryItemsByMonthForUser"(1, '2023-12-01');

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-FileSystemHistoryItems.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-FileSystemHistoryItems.sql
@@ -1,0 +1,10 @@
+UPDATE public."FileSystemHistoryItem" fshi
+SET
+  "InstallStatus" = fsi."InstallStatus"
+FROM (
+  SELECT
+    "Id"
+    , ("RawData"->>'install_status')::int AS "InstallStatus"
+  FROM public."FileSystemHistoryItem"
+) fsi
+WHERE fsi."Id" = fshi."Id";

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-FileSystemItems.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-FileSystemItems.sql
@@ -1,0 +1,10 @@
+UPDATE public."FileSystemItem" fshi
+SET
+  "InstallStatus" = fsi."InstallStatus"
+FROM (
+  SELECT
+    "ServiceNowKey"
+    , ("RawData"->>'install_status')::int AS "InstallStatus"
+  FROM public."FileSystemItem"
+) fsi
+WHERE fsi."ServiceNowKey" = fshi."ServiceNowKey";

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-ServerHistoryItems.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-ServerHistoryItems.sql
@@ -1,0 +1,10 @@
+UPDATE public."ServerHistoryItem" fshi
+SET
+  "InstallStatus" = fsi."InstallStatus"
+FROM (
+  SELECT
+    "Id"
+    , ("RawData"->>'install_status')::int AS "InstallStatus"
+  FROM public."ServerHistoryItem"
+) fsi
+WHERE fsi."Id" = fshi."Id";

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-ServerItems.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/00-ServerItems.sql
@@ -1,0 +1,10 @@
+UPDATE public."ServerItem" fshi
+SET
+  "InstallStatus" = fsi."InstallStatus"
+FROM (
+  SELECT
+    "ServiceNowKey"
+    , ("RawData"->>'install_status')::int AS "InstallStatus"
+  FROM public."ServerItem"
+) fsi
+WHERE fsi."ServiceNowKey" = fshi."ServiceNowKey";

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindFileSystemHistoryItemsByMonth.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindFileSystemHistoryItemsByMonth.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION "FindFileSystemHistoryItemsByMonth"(
+  "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serverServiceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."FileSystemHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "ServiceNowKey"
+    , "RawData"
+    , "RawDataCI"
+    , "Name"
+    , "Label"
+    , "Category"
+    , "Subcategory"
+    , "StorageType"
+    , "MediaType"
+    , "VolumeId"
+    , "ClassName"
+    , "Capacity"
+    , "DiskSpace"
+    , "Size"
+    , "SizeBytes"
+    , "UsedSizeBytes"
+    , "AvailableSpace"
+    , "FreeSpace"
+    , "FreeSpaceBytes"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "ServerItemServiceNowKey"
+    , "InstallStatus"
+  FROM (
+    SELECT fshi.*
+      , ROW_NUMBER() OVER (PARTITION BY fshi."ServiceNowKey", EXTRACT(YEAR FROM fshi."CreatedOn"), EXTRACT(MONTH FROM fshi."CreatedOn") ORDER BY fshi."CreatedOn") AS "rn"
+    FROM public."FileSystemHistoryItem" AS fshi
+    JOIN public."FileSystemItem" AS fsi ON fshi."ServiceNowKey" = fsi."ServiceNowKey"
+    JOIN public."ServerItem" AS si ON fsi."ServerItemServiceNowKey" = si."ServiceNowKey"
+    WHERE fshi."InstallStatus" = 1
+      AND fshi."CreatedOn" >= $1
+      AND ($2 IS NULL OR fshi."CreatedOn" <= $2)
+      AND ($3 IS NULL OR si."TenantId" = $3)
+      AND ($4 IS NULL OR si."OrganizationId" = $4)
+      AND ($5 IS NULL OR si."OperatingSystemItemId" = $5)
+      AND ($6 IS NULL OR fshi."ServerItemServiceNowKey" = $6)
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindFileSystemHistoryItemsByMonthForUser.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindFileSystemHistoryItemsByMonthForUser.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION "FindFileSystemHistoryItemsByMonthForUser"(
+  "userId" INT
+  , "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serverServiceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."FileSystemHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "ServiceNowKey"
+    , "RawData"
+    , "RawDataCI"
+    , "Name"
+    , "Label"
+    , "Category"
+    , "Subcategory"
+    , "StorageType"
+    , "MediaType"
+    , "VolumeId"
+    , "ClassName"
+    , "Capacity"
+    , "DiskSpace"
+    , "Size"
+    , "SizeBytes"
+    , "UsedSizeBytes"
+    , "AvailableSpace"
+    , "FreeSpace"
+    , "FreeSpaceBytes"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "ServerItemServiceNowKey"
+    , "InstallStatus"
+  FROM (
+    SELECT fshi.*
+      , ROW_NUMBER() OVER (PARTITION BY fshi."ServiceNowKey", EXTRACT(YEAR FROM fshi."CreatedOn"), EXTRACT(MONTH FROM fshi."CreatedOn") ORDER BY fshi."CreatedOn") AS "rn"
+    FROM public."FileSystemHistoryItem" AS fshi
+    JOIN public."FileSystemItem" AS fsi ON fshi."ServiceNowKey" = fsi."ServiceNowKey"
+    JOIN public."ServerItem" AS si ON fsi."ServerItemServiceNowKey" = si."ServiceNowKey"
+    WHERE fshi."InstallStatus" = 1
+      AND fshi."CreatedOn" >= $2
+      AND ($3 IS NULL OR fshi."CreatedOn" <= $3)
+      AND ($4 IS NULL OR si."TenantId" = $4)
+      AND ($5 IS NULL OR si."OrganizationId" = $5)
+      AND ($6 IS NULL OR si."OperatingSystemItemId" = $6)
+      AND ($7 IS NULL OR fshi."ServerItemServiceNowKey" = $7)
+      AND (si."TenantId" IN (SELECT "TenantId" FROM public."UserTenant" WHERE "UserId" = $1)
+        OR si."OrganizationId" IN (SELECT "OrganizationId" FROM public."UserOrganization" WHERE "UserId" = $1))
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindServerHistoryItemsByMonth.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindServerHistoryItemsByMonth.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION "FindServerHistoryItemsByMonth"(
+  "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serviceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."ServerHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "TenantId"
+    , "OrganizationId"
+    , "OperatingSystemItemId"
+    , "ServiceNowKey"
+    , "HistoryKey"
+    , "RawData"
+    , "RawDataCI"
+    , "ClassName"
+    , "Name"
+    , "Category"
+    , "Subcategory"
+    , "DnsDomain"
+    , "Platform"
+    , "IPAddress"
+    , "FQDN"
+    , "DiskSpace"
+    , "Capacity"
+    , "AvailableSpace"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "InstallStatus"
+  FROM (
+    SELECT *
+      , ROW_NUMBER() OVER (PARTITION BY "ServiceNowKey", EXTRACT(YEAR FROM "CreatedOn"), EXTRACT(MONTH FROM "CreatedOn") ORDER BY "CreatedOn") AS "rn"
+    FROM public."ServerHistoryItem"
+    WHERE "InstallStatus" = 1
+      AND "CreatedOn" >= $1
+      AND ($2 IS NULL OR "CreatedOn" <= $2)
+      AND ($3 IS NULL OR "TenantId" = $3)
+      AND ($4 IS NULL OR "OrganizationId" = $4)
+      AND ($5 IS NULL OR "OperatingSystemItemId" = $5)
+      AND ($6 IS NULL OR "ServiceNowKey" = $6)
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$
+
+-- Use by calling
+-- select * from public."FindServerHistoryItemsByMonth"('2023-12-01');

--- a/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindServerHistoryItemsByMonthForUser.sql
+++ b/src/libs/dal/Migrations/1.0.1/Up/PostUp/01-FindServerHistoryItemsByMonthForUser.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION "FindServerHistoryItemsByMonthForUser"(
+  "userId" INT
+  , "startDate" TIMESTAMPTZ
+  , "endDate" TIMESTAMPTZ DEFAULT NULL
+  , "tenantId" INT DEFAULT NULL
+  , "organizationId" INT DEFAULT NULL
+  , "operatingSystemItemId" INT DEFAULT NULL
+  , "serviceNowKey" VARCHAR(200) DEFAULT NULL
+)
+RETURNS SETOF public."ServerHistoryItem"
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT
+    "Id"
+    , "TenantId"
+    , "OrganizationId"
+    , "OperatingSystemItemId"
+    , "ServiceNowKey"
+    , "HistoryKey"
+    , "RawData"
+    , "RawDataCI"
+    , "ClassName"
+    , "Name"
+    , "Category"
+    , "Subcategory"
+    , "DnsDomain"
+    , "Platform"
+    , "IPAddress"
+    , "FQDN"
+    , "DiskSpace"
+    , "Capacity"
+    , "AvailableSpace"
+    , "CreatedOn"
+    , "CreatedBy"
+    , "UpdatedOn"
+    , "UpdatedBy"
+    , "Version"
+    , "InstallStatus"
+  FROM (
+    SELECT shi.*
+      , ROW_NUMBER() OVER (PARTITION BY shi."ServiceNowKey", EXTRACT(YEAR FROM shi."CreatedOn"), EXTRACT(MONTH FROM shi."CreatedOn") ORDER BY shi."CreatedOn") AS "rn"
+    FROM public."ServerHistoryItem" shi
+    JOIN public."ServerItem" si ON shi."ServiceNowKey" = si."ServiceNowKey"
+    WHERE shi."InstallStatus" = 1
+      AND shi."CreatedOn" >= $2
+      AND ($3 IS NULL OR shi."CreatedOn" <= $3)
+      AND ($4 IS NULL OR shi."TenantId" = $4)
+      AND ($5 IS NULL OR shi."OrganizationId" = $5)
+      AND ($6 IS NULL OR shi."OperatingSystemItemId" = $6)
+      AND ($7 IS NULL OR shi."ServiceNowKey" = $7)
+      AND (si."TenantId" IN (SELECT "TenantId" FROM public."UserTenant" WHERE "UserId" = $1)
+        OR si."OrganizationId" IN (SELECT "OrganizationId" FROM public."UserOrganization" WHERE "UserId" = $1))
+  ) AS "sub"
+  WHERE "rn" = 1
+  ORDER BY "ServiceNowKey", "CreatedOn";
+END;$$
+
+-- Use by calling
+-- select * from public."FindServerHistoryItemsByMonthForUser"(1, '2023-12-01');

--- a/src/libs/dal/Migrations/20240220144234_1.0.1.Designer.cs
+++ b/src/libs/dal/Migrations/20240220144234_1.0.1.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using HSB.DAL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HSB.DAL.Migrations
 {
     [DbContext(typeof(HSBContext))]
-    partial class HSBContextModelSnapshot : ModelSnapshot
+    [Migration("20240220144234_1.0.1")]
+    partial class _101
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/libs/dal/Migrations/20240220144234_1.0.1.cs
+++ b/src/libs/dal/Migrations/20240220144234_1.0.1.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using HSB.DAL;
+
+#nullable disable
+
+namespace HSB.DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class _101 : PostgresSeedMigration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            PreUp(migrationBuilder);
+            migrationBuilder.DropIndex(
+                name: "IX_ServerItem_Name",
+                table: "ServerItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FileSystemItem_Name_ServerItemServiceNowKey",
+                table: "FileSystemItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FileSystemHistoryItem_ServiceNowKey_ServerItemServiceNowKey",
+                table: "FileSystemHistoryItem");
+
+            migrationBuilder.AddColumn<int>(
+                name: "InstallStatus",
+                table: "ServerItem",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InstallStatus",
+                table: "ServerHistoryItem",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InstallStatus",
+                table: "FileSystemItem",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InstallStatus",
+                table: "FileSystemHistoryItem",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerItem_InstallStatus_UpdatedOn",
+                table: "ServerItem",
+                columns: new[] { "InstallStatus", "UpdatedOn" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerHistoryItem_InstallStatus_ServiceNowKey",
+                table: "ServerHistoryItem",
+                columns: new[] { "InstallStatus", "ServiceNowKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileSystemItem_InstallStatus_ServerItemServiceNowKey",
+                table: "FileSystemItem",
+                columns: new[] { "InstallStatus", "ServerItemServiceNowKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileSystemHistoryItem_InstallStatus_ServiceNowKey_ServerItemServiceNowKey",
+                table: "FileSystemHistoryItem",
+                columns: new[] { "InstallStatus", "ServiceNowKey", "ServerItemServiceNowKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileSystemHistoryItem_ServiceNowKey",
+                table: "FileSystemHistoryItem",
+                column: "ServiceNowKey");
+            PostUp(migrationBuilder);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            PreDown(migrationBuilder);
+            migrationBuilder.DropIndex(
+                name: "IX_ServerItem_InstallStatus_UpdatedOn",
+                table: "ServerItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ServerHistoryItem_InstallStatus_ServiceNowKey",
+                table: "ServerHistoryItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FileSystemItem_InstallStatus_ServerItemServiceNowKey",
+                table: "FileSystemItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FileSystemHistoryItem_InstallStatus_ServiceNowKey_ServerItemServiceNowKey",
+                table: "FileSystemHistoryItem");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FileSystemHistoryItem_ServiceNowKey",
+                table: "FileSystemHistoryItem");
+
+            migrationBuilder.DropColumn(
+                name: "InstallStatus",
+                table: "ServerItem");
+
+            migrationBuilder.DropColumn(
+                name: "InstallStatus",
+                table: "ServerHistoryItem");
+
+            migrationBuilder.DropColumn(
+                name: "InstallStatus",
+                table: "FileSystemItem");
+
+            migrationBuilder.DropColumn(
+                name: "InstallStatus",
+                table: "FileSystemHistoryItem");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ServerItem_Name",
+                table: "ServerItem",
+                column: "Name");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileSystemItem_Name_ServerItemServiceNowKey",
+                table: "FileSystemItem",
+                columns: new[] { "Name", "ServerItemServiceNowKey" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FileSystemHistoryItem_ServiceNowKey_ServerItemServiceNowKey",
+                table: "FileSystemHistoryItem",
+                columns: new[] { "ServiceNowKey", "ServerItemServiceNowKey" });
+            PostDown(migrationBuilder);
+        }
+    }
+}

--- a/src/libs/entities/FileSystemHistoryItem.cs
+++ b/src/libs/entities/FileSystemHistoryItem.cs
@@ -29,6 +29,7 @@ public class FileSystemHistoryItem : Auditable
     public JsonDocument RawData { get; set; } = JsonDocument.Parse("{}");
     public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Label { get; set; } = "";
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
@@ -60,6 +61,7 @@ public class FileSystemHistoryItem : Auditable
         this.ServiceNowKey = fileSystemItemData.GetElementValue<string>(".sys_id") ?? "";
         this.ClassName = fileSystemItemData.GetElementValue<string>(".sys_class_name") ?? "";
         this.Name = fileSystemItemData.GetElementValue<string>(".name") ?? "";
+        this.InstallStatus = fileSystemItemData.GetElementValue<int>(".install_status");
         this.Label = fileSystemItemData.GetElementValue<string>(".label") ?? "";
         this.Category = fileSystemItemData.GetElementValue<string>(".category") ?? "";
         this.Subcategory = fileSystemItemData.GetElementValue<string>(".subcategory") ?? "";
@@ -86,6 +88,7 @@ public class FileSystemHistoryItem : Auditable
 
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Label = entity.Label;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;

--- a/src/libs/entities/FileSystemItem.cs
+++ b/src/libs/entities/FileSystemItem.cs
@@ -25,6 +25,7 @@ public class FileSystemItem : Auditable
     public JsonDocument RawData { get; set; } = JsonDocument.Parse("{}");
     public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Label { get; set; } = "";
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
@@ -67,6 +68,7 @@ public class FileSystemItem : Auditable
         this.ServiceNowKey = fileSystemItemData.GetElementValue<string>(".sys_id") ?? "";
         this.ClassName = fileSystemItemData.GetElementValue<string>(".sys_class_name") ?? "";
         this.Name = fileSystemItemData.GetElementValue<string>(".name") ?? "";
+        this.InstallStatus = fileSystemItemData.GetElementValue<int>(".install_status");
         this.Label = fileSystemItemData.GetElementValue<string>(".label") ?? "";
         this.Category = fileSystemItemData.GetElementValue<string>(".category") ?? "";
         this.Subcategory = fileSystemItemData.GetElementValue<string>(".subcategory") ?? "";

--- a/src/libs/entities/ServerHistoryItem.cs
+++ b/src/libs/entities/ServerHistoryItem.cs
@@ -28,6 +28,7 @@ public class ServerHistoryItem : Auditable
     public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
     public string DnsDomain { get; set; } = "";
@@ -66,6 +67,7 @@ public class ServerHistoryItem : Auditable
         this.ServiceNowKey = serverData.GetElementValue<string>(".sys_id") ?? "";
         this.ClassName = serverData.GetElementValue<string>(".sys_class_name") ?? "";
         this.Name = serverData.GetElementValue<string>(".name") ?? "";
+        this.InstallStatus = serverData.GetElementValue<int>(".install_status");
         this.Category = serverData.GetElementValue<string>(".category") ?? "";
         this.Subcategory = serverData.GetElementValue<string>(".subcategory") ?? "";
         this.DnsDomain = serverData.GetElementValue<string>(".dns_domain") ?? "";
@@ -89,6 +91,7 @@ public class ServerHistoryItem : Auditable
 
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;
         this.DnsDomain = entity.DnsDomain;

--- a/src/libs/entities/ServerItem.cs
+++ b/src/libs/entities/ServerItem.cs
@@ -54,6 +54,7 @@ public class ServerItem : Auditable
     public string Name { get; set; } = "";
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string DnsDomain { get; set; } = "";
     public string Platform { get; set; } = "";
     public string IPAddress { get; set; } = "";
@@ -100,6 +101,7 @@ public class ServerItem : Auditable
         this.ServiceNowKey = serverData.GetElementValue<string>(".sys_id") ?? "";
         this.ClassName = serverData.GetElementValue<string>(".sys_class_name") ?? "";
         this.Name = serverData.GetElementValue<string>(".name") ?? "";
+        this.InstallStatus = serverData.GetElementValue<int>(".install_status");
         this.Category = serverData.GetElementValue<string>(".category") ?? "";
         this.Subcategory = serverData.GetElementValue<string>(".subcategory") ?? "";
         this.DnsDomain = serverData.GetElementValue<string>(".dns_domain") ?? "";

--- a/src/libs/models/FileSystemHistoryItemModel.cs
+++ b/src/libs/models/FileSystemHistoryItemModel.cs
@@ -14,6 +14,7 @@ public class FileSystemHistoryItemModel : AuditableModel
     public string ServerItemServiceNowKey { get; set; } = "";
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Label { get; set; } = "";
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
@@ -44,6 +45,7 @@ public class FileSystemHistoryItemModel : AuditableModel
         this.ServerItemServiceNowKey = entity.ServerItemServiceNowKey;
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Label = entity.Label;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;
@@ -76,6 +78,7 @@ public class FileSystemHistoryItemModel : AuditableModel
 
         this.ClassName = fileSystemItemModel.Data.ClassName ?? "";
         this.Name = fileSystemItemModel.Data.Name ?? "";
+        this.InstallStatus = int.Parse(fileSystemItemModel.Data.InstallStatus ?? "0");
         this.Label = fileSystemItemModel.Data.Label ?? "";
         this.Category = fileSystemItemModel.Data.Category ?? "";
         this.Subcategory = fileSystemItemModel.Data.Subcategory ?? "";
@@ -109,6 +112,7 @@ public class FileSystemHistoryItemModel : AuditableModel
             ServiceNowKey = model.ServiceNowKey,
             ClassName = model.ClassName,
             Name = model.Name,
+            InstallStatus = model.InstallStatus,
             Label = model.Label,
             Category = model.Category,
             Subcategory = model.Subcategory,

--- a/src/libs/models/FileSystemItemModel.cs
+++ b/src/libs/models/FileSystemItemModel.cs
@@ -13,6 +13,7 @@ public class FileSystemItemModel : AuditableModel
     public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Label { get; set; } = "";
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
@@ -42,6 +43,7 @@ public class FileSystemItemModel : AuditableModel
 
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Label = entity.Label;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;
@@ -73,6 +75,7 @@ public class FileSystemItemModel : AuditableModel
 
         this.ClassName = fileSystemItemModel.Data.ClassName ?? "";
         this.Name = fileSystemItemModel.Data.Name ?? "";
+        this.InstallStatus = int.Parse(fileSystemItemModel.Data.InstallStatus ?? "0");
         this.Label = fileSystemItemModel.Data.Label ?? "";
         this.Category = fileSystemItemModel.Data.Category ?? "";
         this.Subcategory = fileSystemItemModel.Data.Subcategory ?? "";
@@ -105,6 +108,7 @@ public class FileSystemItemModel : AuditableModel
             ServiceNowKey = model.ServiceNowKey,
             ClassName = model.ClassName,
             Name = model.Name,
+            InstallStatus = model.InstallStatus,
             Label = model.Label,
             Category = model.Category,
             Subcategory = model.Subcategory,

--- a/src/libs/models/Filters/ServerItemFilter.cs
+++ b/src/libs/models/Filters/ServerItemFilter.cs
@@ -12,8 +12,16 @@ public class ServerItemFilter : PageFilter
     public int? TenantId { get; set; }
     public int? OrganizationId { get; set; }
     public int? OperatingSystemItemId { get; set; }
+    public int? InstallStatus { get; set; }
+    public int? NotInstallStatus { get; set; }
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
+
+    /// <summary>
+    /// get/set - Find server items that were updated before this date.
+    /// This is used to find server items that did not receive an update in the current sync.
+    /// </summary>
+    public DateTime? UpdatedBeforeDate { get; set; }
 
     public string[] Sort { get; set; } = Array.Empty<string>();
     #endregion
@@ -32,6 +40,9 @@ public class ServerItemFilter : PageFilter
         this.OperatingSystemItemId = filter.GetIntNullValue(nameof(this.OperatingSystemItemId));
         this.StartDate = filter.GetDateTimeNullValue(nameof(this.StartDate));
         this.EndDate = filter.GetDateTimeNullValue(nameof(this.EndDate));
+        this.UpdatedBeforeDate = filter.GetDateTimeNullValue(nameof(this.UpdatedBeforeDate));
+        this.InstallStatus = filter.GetIntNullValue(nameof(this.InstallStatus));
+        this.NotInstallStatus = filter.GetIntNullValue(nameof(this.NotInstallStatus));
 
         this.Sort = filter.GetStringArrayValue(nameof(this.Sort), new[] { nameof(ServerItemModel.Name) });
     }
@@ -51,10 +62,16 @@ public class ServerItemFilter : PageFilter
             predicate = predicate.And((u) => u.OrganizationId == this.OrganizationId);
         if (this.OperatingSystemItemId != null)
             predicate = predicate.And((u) => u.OperatingSystemItemId == this.OperatingSystemItemId);
+        if (this.InstallStatus != null)
+            predicate = predicate.And((u) => u.InstallStatus == this.InstallStatus);
+        if (this.NotInstallStatus != null)
+            predicate = predicate.And((u) => u.InstallStatus != this.NotInstallStatus);
         if (this.StartDate != null)
             predicate = predicate.And((u) => u.CreatedOn >= this.StartDate.Value.ToUniversalTime());
         if (this.EndDate != null)
             predicate = predicate.And((u) => u.CreatedOn <= this.EndDate.Value.ToUniversalTime());
+        if (this.UpdatedBeforeDate != null)
+            predicate = predicate.And((u) => u.UpdatedOn < this.UpdatedBeforeDate.Value.ToUniversalTime());
 
         if (!predicate.IsStarted) return predicate.And((u) => true);
         return predicate;

--- a/src/libs/models/ServerHistoryItemModel.cs
+++ b/src/libs/models/ServerHistoryItemModel.cs
@@ -20,6 +20,7 @@ public class ServerHistoryItemModel : AuditableModel
     public string ServiceNowKey { get; set; } = "";
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
     public string DnsDomain { get; set; } = "";
@@ -56,6 +57,7 @@ public class ServerHistoryItemModel : AuditableModel
         this.ServiceNowKey = entity.ServiceNowKey;
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;
         this.DnsDomain = entity.DnsDomain;
@@ -88,6 +90,7 @@ public class ServerHistoryItemModel : AuditableModel
         this.ServiceNowKey = serverModel.Data.Id;
         this.ClassName = serverModel.Data.ClassName ?? "";
         this.Name = serverModel.Data.Name ?? "";
+        this.InstallStatus = int.Parse(serverModel.Data.InstallStatus ?? "0");
         this.Category = serverModel.Data.Category ?? "";
         this.Subcategory = serverModel.Data.Subcategory ?? "";
         this.DnsDomain = serverModel.Data.DnsDomain ?? "";
@@ -114,6 +117,7 @@ public class ServerHistoryItemModel : AuditableModel
             ServiceNowKey = model.ServiceNowKey,
             ClassName = model.ClassName,
             Name = model.Name,
+            InstallStatus = model.InstallStatus,
             Category = model.Category,
             Subcategory = model.Subcategory,
             DnsDomain = model.DnsDomain,

--- a/src/libs/models/ServerItemModel.cs
+++ b/src/libs/models/ServerItemModel.cs
@@ -22,6 +22,7 @@ public class ServerItemModel : AuditableModel
     public JsonDocument RawDataCI { get; set; } = JsonDocument.Parse("{}");
     public string ClassName { get; set; } = "";
     public string Name { get; set; } = "";
+    public int InstallStatus { get; set; }
     public string Category { get; set; } = "";
     public string Subcategory { get; set; } = "";
     public string DnsDomain { get; set; } = "";
@@ -57,6 +58,7 @@ public class ServerItemModel : AuditableModel
 
         this.ClassName = entity.ClassName;
         this.Name = entity.Name;
+        this.InstallStatus = entity.InstallStatus;
         this.Category = entity.Category;
         this.Subcategory = entity.Subcategory;
         this.DnsDomain = entity.DnsDomain;
@@ -92,6 +94,7 @@ public class ServerItemModel : AuditableModel
 
         this.ClassName = serverModel.Data.ClassName ?? "";
         this.Name = serverModel.Data.Name ?? "";
+        this.InstallStatus = int.Parse(serverModel.Data.InstallStatus ?? "0");
         this.Category = serverModel.Data.Category ?? "";
         this.Subcategory = serverModel.Data.Subcategory ?? "";
         this.DnsDomain = serverModel.Data.DnsDomain ?? "";
@@ -117,6 +120,7 @@ public class ServerItemModel : AuditableModel
             ServiceNowKey = model.ServiceNowKey,
             ClassName = model.ClassName,
             Name = model.Name,
+            InstallStatus = model.InstallStatus,
             Category = model.Category,
             Subcategory = model.Subcategory,
             DnsDomain = model.DnsDomain,


### PR DESCRIPTION
Made several changes to resolve data issues.  Added a new processes to the end of the Data Service syncing process.  This will now review all server items that were not updated in the sync and iterate through them to determine if their install status needs to be updated.  We now extract the `install_status` and use it to index and filter data.

We now filter out server items and file system items that are not installed within our database.  This partially resolves items that are removed.

Fixed a few bugs related to querying data when an item had no link to a tenant.

> Run `bash do db-update` to update your local environment database.  Then `bash do refresh api` to update your API.

## Summary

- Add DB migration 1.0.1
- Updated Data Service
- Updated API
- Updated App