### PR TITLE
HOSTSD-271 - Updating Breadcrumbs and adding totals to server charts

### DIFF
--- a/src/dashboard/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/dashboard/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,20 @@
 import styles from './Breadcrumbs.module.scss';
-import { useFilteredStore } from '@/store';
+import { useDashboardStore } from '@/store';
 
 interface BreadcrumbsProps {
     multipleOrganizations: boolean;
 }
 
 export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ multipleOrganizations }) => {
-  const values = useFilteredStore((state) => state.values);
+  const {
+    organization,
+    operatingSystemItem,
+    serverItem,
+  } = useDashboardStore(state => ({
+    organization: state.organization,
+    operatingSystemItem: state.operatingSystemItem,
+    serverItem: state.serverItem,
+  }));
 
   return (
     <div className={styles.breadcrumbs}>
@@ -15,19 +23,19 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ multipleOrganizations 
             <p>All Organizations</p>
         </div>
        )}
-      {!!values.organization && (
+      {!!organization && (
         <div>
-          <p title={values.organization.name}>{values.organization.name}</p>
+          <p title={organization.name}>{organization.name}</p>
         </div>
       )}
-      {!!values.operatingSystemItem && (
+      {!!operatingSystemItem && (
         <div>
-          <p title={values.operatingSystemItem.name}>{values.operatingSystemItem.name}</p>
+          <p title={operatingSystemItem.name}>{operatingSystemItem.name}</p>
         </div>
       )}
-      {!!values.serverItem && (
+      {!!serverItem && (
         <div>
-          <p title={values.serverItem.name}>{values.serverItem.name}</p>
+          <p title={serverItem.name}>{serverItem.name}</p>
         </div>
       )}
     </div>

--- a/src/dashboard/src/components/charts/allocationTable/AllocationTable.module.scss
+++ b/src/dashboard/src/components/charts/allocationTable/AllocationTable.module.scss
@@ -7,6 +7,10 @@
     >button {
         @include export-btn;
     }
+
+    h2 {
+        margin: 12px 0 16px;
+    }
 }
 
 .filter {

--- a/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
+++ b/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
@@ -13,7 +13,7 @@ import { ITableRowData } from './ITableRowData';
 import { TableRow } from './TableRow';
 import { useAllocationByOS } from './hooks';
 import { getColumns, getLabel } from './utils';
-import { convertToStorageSize } from './../../../utils/convertToStorageSize';
+import { convertToStorageSize } from '@/utils/convertToStorageSize';
 export interface IAllocationTableProps {
   /** Filter servers by their OS */
   osClassName?: string;

--- a/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
+++ b/src/dashboard/src/components/charts/allocationTable/AllocationTable.tsx
@@ -13,7 +13,7 @@ import { ITableRowData } from './ITableRowData';
 import { TableRow } from './TableRow';
 import { useAllocationByOS } from './hooks';
 import { getColumns, getLabel } from './utils';
-
+import { convertToStorageSize } from './../../../utils/convertToStorageSize';
 export interface IAllocationTableProps {
   /** Filter servers by their OS */
   osClassName?: string;
@@ -59,6 +59,12 @@ export const AllocationTable = ({
     setRows(rows);
   }, [serverItems, filter, getServerItems, sort]);
 
+  const totalCapacity = rows.reduce((acc, row) => acc + (row.capacity || 0), 0);
+  const capacityValue = convertToStorageSize<string>(totalCapacity, 'B', 'TB');
+
+  const totalUnused = rows.reduce((acc, row) => acc + (row.available || 0), 0);
+  const unusedValue = convertToStorageSize<string>(totalUnused, 'B', 'TB');
+
   const showTenants = React.useMemo(() => rows.some((data) => data.tenant), [rows]);
   const columns = React.useMemo(() => getColumns(showTenants), [showTenants]);
 
@@ -100,6 +106,18 @@ export const AllocationTable = ({
     };
   }, []);
 
+  // Check if all servers have the same OS and return that OS name
+  const getCommonOSName = (serverRows: ITableRowData<IServerItemModel>[]): string | null => {
+    if (serverRows.length === 0) return null; // Early exit if no servers
+  
+    const firstOS = serverRows[0].os;
+    const commonOS = serverRows.every(row => row.os === firstOS);
+  
+    return commonOS ? firstOS : null;
+  };
+
+  const commonOSName = React.useMemo(() => getCommonOSName(rows), [rows]);
+
   return (
     <div className={styles.panel} style={margin ? { marginTop: margin } : {}}>
       {loading && <LoadingAnimation />}
@@ -108,8 +126,9 @@ export const AllocationTable = ({
           ? `Allocation by Storage Volume - All ${serverItems.length.toLocaleString()} ${getLabel(
               osClassName,
             )}`
-          : `All ${serverItems.length.toLocaleString()} Servers`}
+          : `${serverItems.length.toLocaleString()} Servers ${commonOSName ? `using OS: "${commonOSName}"` : ''}`}
       </h1>
+      <h2>Allocated Storage: {capacityValue} &nbsp;|&nbsp; Unused Storage: {unusedValue}</h2>
       <div className={styles.filter} ref={wrapperRef}>
         <Text
           placeholder="Filter by server name, OS version"

--- a/src/dashboard/src/components/charts/doughnut/totalStorage/TotalStorage.module.scss
+++ b/src/dashboard/src/components/charts/doughnut/totalStorage/TotalStorage.module.scss
@@ -35,6 +35,8 @@
 
 .footer {
     display: flex;
+    justify-content: space-between;
+    gap: 0;
     margin-top: 10px;
     font-size: $font-size-small;
 
@@ -52,9 +54,7 @@
         border-radius: 50%;
     }
 
-    p:last-child {
-        margin-left: 25px;
-
+    p:last-child {        
         &::before {
             opacity: .4;
         }

--- a/src/dashboard/src/components/header/Message.tsx
+++ b/src/dashboard/src/components/header/Message.tsx
@@ -1,10 +1,18 @@
-import { useAppStore, useFilteredStore } from '@/store';
+import { useAppStore, useDashboardStore } from '@/store';
 import { usePathname } from 'next/navigation';
 
 export const Message = () => {
   const path = usePathname();
   const userInfo = useAppStore((state) => state.userinfo);
-  const values = useFilteredStore((state) => state.values);
+  const {
+    organization,
+    operatingSystemItem,
+    serverItem,
+  } = useDashboardStore((state) => ({
+    organization: state.organization,
+    operatingSystemItem: state.operatingSystemItem,
+    serverItem: state.serverItem,
+  }));
   const operatingSystemItems = useAppStore((state) => state.operatingSystemItems);
 
   const isDashboardView = path.includes('/dashboard');
@@ -14,47 +22,47 @@ export const Message = () => {
   const isClientOrganizationAdminView = path.includes('/client/admin/organizations');
 
   if (isDashboardView) {
-    if (!!values.organization && !!values.serverItem) {
+    if (!!organization && !!serverItem) {
       return (
         <p>
-          Showing results for: {values.organization.name}, {values.serverItem.name}
+          Showing results for: {organization.name}, {serverItem.name}
         </p>
       );
     }
 
-    if (values.serverItem) {
+    if (serverItem) {
       var os = operatingSystemItems.find(
-        (os) => os.id === values.serverItem?.operatingSystemItemId,
+        (os) => os.id === serverItem?.operatingSystemItemId,
       );
       return (
         <p>
-          Showing results for: {values.serverItem.name}
+          Showing results for: {serverItem.name}
           {os ? `: ${os.name}` : ''}
         </p>
       );
     }
 
-    if (!!values.organization && !!values.operatingSystemItem)
+    if (!!organization && !!operatingSystemItem)
       return (
         <p>
-          Showing results for: {values.organization.name}, all {values.operatingSystemItem.name}{' '}
+          Showing results for: {organization.name}, all {operatingSystemItem.name}{' '}
           servers. <br />
           Use the filters to see further breakdowns of storage data.
         </p>
       );
 
-    if (!!values.organization)
+    if (!!organization)
       return (
         <p>
-          Showing results for: {values.organization.name}. <br />
+          Showing results for: {organization.name}. <br />
           Use the filters to see further breakdowns of storage data.
         </p>
       );
 
-    if (!!values.operatingSystemItem)
+    if (!!operatingSystemItem)
       return (
         <p>
-          Showing results for: all {values.operatingSystemItem.name} servers. <br />
+          Showing results for: all {operatingSystemItem.name} servers. <br />
           Use the filters to see further breakdowns of storage data.
         </p>
       );


### PR DESCRIPTION
- Updating breadcrumbs and header messaging so they only update after the dashboard has been updated (after 'update' button in Filter is clicked).  Using `useDashboardStore` instead of `useFilteredStore`.
- Server charts: Adding OS name to chart when looking at single OS page.  Adding totals for allocated and unused space at the top of the charts.
- Including a few small style fixes