### PR TITLE
HOSTSD-317 - fixing dropdown covered by loading overlay bug

### DIFF
--- a/src/dashboard/src/components/filter/Filter.module.scss
+++ b/src/dashboard/src/components/filter/Filter.module.scss
@@ -15,7 +15,17 @@
   transform: translateX(-50%);
   left: 50%;
   color: $bc-black;
-  z-index: 1;
+  z-index: 2;
+
+  h1 {
+    min-width: 100px;
+  }
+
+  @media (min-width: $mobile) {
+    >div:last-of-type {
+      margin-right: 14px;
+    }
+  }
 
   @media (max-width: $desktop) {
     h1 {

--- a/src/dashboard/src/components/forms/select/Select.module.scss
+++ b/src/dashboard/src/components/forms/select/Select.module.scss
@@ -51,7 +51,7 @@
   flex-direction: column;
   position: relative;
   width: 100%;
-  max-width: 255px;
+  margin: 0 7px;
 
   @media screen and (max-width: $desktop) {
     margin: 0 5px;


### PR DESCRIPTION
- Adjusted the filter dropdown z-index so that they are no longer covered by the chart loading overlays.
- Adjusted the width for the filter dropdowns so they take up the empty space if one is not displayed.