### PR TITLE
HOSTSD-293 - fix for storage trends chart aspect ratio bug

### DIFF
--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -173,6 +173,26 @@ export const Dashboard = () => {
     [download],
   );
 
+  const renderStorageTrendsChart = (isLarge: boolean) => {
+    return (
+      <StorageTrendsChart
+        large={isLarge}
+        serverItems={dashboardServerItem ? [dashboardServerItem] : dashboardServerItems}
+        showExport
+        onExport={(startDate, endDate) => {
+          handleExport({
+            tenantId: dashboardTenant?.id,
+            organizationId: dashboardOrganization?.id,
+            operatingSystemItemId: dashboardOperatingSystemItem?.id,
+            serviceNowKey: dashboardServerItem?.serviceNowKey,
+            startDate: startDate,
+            endDate: endDate,
+          });
+        }}
+      />
+    );
+  };
+
   return (
     <>
       <Breadcrumbs multipleOrganizations={organizations.length > 1} />
@@ -254,31 +274,20 @@ export const Dashboard = () => {
       )}
       {/* Multiple Organizations */}
       {showAllOrganizations && (
-        <AllOrganizations
-          organizations={dashboardOrganizations}
-          serverItems={dashboardServerItems}
-          loading={!isReadyOrganizations || !isReadyServerItems}
-          showExport
-          onExport={() => {
-            handleExport({ tenantId: dashboardTenant?.id });
-          }}
-        />
+        <>
+          <AllOrganizations
+            organizations={dashboardOrganizations}
+            serverItems={dashboardServerItems}
+            loading={!isReadyOrganizations || !isReadyServerItems}
+            showExport
+            onExport={() => {
+              handleExport({ tenantId: dashboardTenant?.id });
+            }}
+          />
+          {renderStorageTrendsChart(false)}
+        </>
       )}
-      <StorageTrendsChart
-        large={!!dashboardOrganization || !!dashboardOperatingSystemItem || !!dashboardServerItem}
-        serverItems={dashboardServerItem ? [dashboardServerItem] : dashboardServerItems}
-        showExport
-        onExport={(startDate, endDate) => {
-          handleExport({
-            tenantId: dashboardTenant?.id,
-            organizationId: dashboardOrganization?.id,
-            operatingSystemItemId: dashboardOperatingSystemItem?.id,
-            serviceNowKey: dashboardServerItem?.serviceNowKey,
-            startDate: startDate,
-            endDate: endDate,
-          });
-        }}
-      />
+      {!showAllOrganizations && renderStorageTrendsChart(true)}
       {showAllocationByStorageVolume && (
         <AllocationByStorageVolume
           organizations={dashboardOrganizations}

--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -173,8 +173,8 @@ export const Dashboard = () => {
     [download],
   );
 
-  const renderStorageTrendsChart = (isLarge: boolean) => {
-    return (
+  const renderStorageTrendsChart = React.useCallback(
+    (isLarge: Boolean) => (
       <StorageTrendsChart
         large={isLarge}
         serverItems={dashboardServerItem ? [dashboardServerItem] : dashboardServerItems}
@@ -190,8 +190,16 @@ export const Dashboard = () => {
           });
         }}
       />
-    );
-  };
+    ),
+    [
+      dashboardServerItem,
+      dashboardServerItems,
+      dashboardTenant,
+      dashboardOrganization,
+      dashboardOperatingSystemItem,
+      handleExport,
+    ]
+  );
 
   return (
     <>

--- a/src/dashboard/src/components/dashboard/Dashboard.tsx
+++ b/src/dashboard/src/components/dashboard/Dashboard.tsx
@@ -174,7 +174,7 @@ export const Dashboard = () => {
   );
 
   const renderStorageTrendsChart = React.useCallback(
-    (isLarge: Boolean) => (
+    (isLarge: boolean | undefined) => (
       <StorageTrendsChart
         large={isLarge}
         serverItems={dashboardServerItem ? [dashboardServerItem] : dashboardServerItems}


### PR DESCRIPTION
The Storage Trends chart aspect ratio was off when navigating back to the All Organizations view - the chart was too short because it was keeping the longer aspect ratio from the larger size of the chart on other views.

To fix this, it seems the chart needs to be rendered separately for each size depending on which view the user is looking at.