### PR TITLE
Adding support for STMS domains

### DIFF
--- a/devops/kustomize/base/app/config-map.yaml
+++ b/devops/kustomize/base/app/config-map.yaml
@@ -8,10 +8,10 @@ metadata:
   labels:
     name: dashboard
     part-of: hsb
-    version: 1.0.0
+    version: 1.0.1
     component: app
     managed-by: kustomize
     created-by: jeremy.foster
 data:
-  NEXTAUTH_URL: https://dev-hsb.apps.emerald.devops.gov.bc.ca/
+  NEXTAUTH_URL: https://dev.dashboard.stms.gov.bc.ca/
   API_URL: http://api:8080

--- a/devops/kustomize/base/app/route.yaml
+++ b/devops/kustomize/base/app/route.yaml
@@ -28,33 +28,33 @@ spec:
     kind: Service
     name: dashboard
     weight: 100
-# ---
-# kind: Route
-# apiVersion: route.openshift.io/v1
-# metadata:
-#   name: dashboard-tls
-#   namespace: default
-#   annotations:
-#     description: Route for dashboard application.
-#   labels:
-#     name: dashboard
-#     part-of: hsb
-#     version: 1.0.0
-#     component: app
-#     managed-by: kustomize
-#     created-by: jeremy.foster
-# spec:
-#   host: hsb.gov.bc.ca
-#   path: ""
-#   port:
-#     targetPort: 8080-tcp
-#   tls:
-#     insecureEdgeTerminationPolicy: Redirect
-#     termination: edge
-#     # caCertificate: ""
-#     # certificate: ""
-#     # key: ""
-#   to:
-#     kind: Service
-#     name: dashboard
-#     weight: 100
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: dashboard-stms
+  namespace: default
+  annotations:
+    description: TLS Route for dashboard application.
+  labels:
+    name: dashboard-stms
+    part-of: hsb
+    version: 1.0.1
+    component: app
+    managed-by: kustomize
+    created-by: brian.price
+spec:
+  host: dev.dashboard.stms.gov.bc.ca
+  path: ""
+  port:
+    targetPort: 8080-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+    # caCertificate: ""
+    # certificate: ""
+    # key: ""
+  to:
+    kind: Service
+    name: dashboard
+    weight: 100

--- a/devops/kustomize/overlays/dev/app/kustomization.yaml
+++ b/devops/kustomize/overlays/dev/app/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://dev-hsb.apps.emerald.devops.gov.bc.ca
+        value: https://dev.dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -53,13 +53,13 @@ patches:
       - op: replace
         path: /spec/host
         value: dev-hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: dev.dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig

--- a/devops/kustomize/overlays/dev/kustomization.yaml
+++ b/devops/kustomize/overlays/dev/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://dev-hsb.apps.emerald.devops.gov.bc.ca
+        value: https://dev.dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -82,13 +82,13 @@ patches:
       - op: replace
         path: /spec/host
         value: dev-hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: dev.dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig

--- a/devops/kustomize/overlays/prod/app/kustomization.yaml
+++ b/devops/kustomize/overlays/prod/app/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://hsb.apps.emerald.devops.gov.bc.ca
+        value: https://dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -53,13 +53,13 @@ patches:
       - op: replace
         path: /spec/host
         value: hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig

--- a/devops/kustomize/overlays/prod/kustomization.yaml
+++ b/devops/kustomize/overlays/prod/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://hsb.apps.emerald.devops.gov.bc.ca
+        value: https://dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -82,13 +82,13 @@ patches:
       - op: replace
         path: /spec/host
         value: hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig

--- a/devops/kustomize/overlays/test/app/kustomization.yaml
+++ b/devops/kustomize/overlays/test/app/kustomization.yaml
@@ -44,7 +44,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://test-hsb.apps.emerald.devops.gov.bc.ca
+        value: https://test.dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -53,13 +53,13 @@ patches:
       - op: replace
         path: /spec/host
         value: test-hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: test.dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig

--- a/devops/kustomize/overlays/test/kustomization.yaml
+++ b/devops/kustomize/overlays/test/kustomization.yaml
@@ -59,7 +59,7 @@ patches:
     patch: |-
       - op: replace
         path: /data/NEXTAUTH_URL
-        value: https://test-hsb.apps.emerald.devops.gov.bc.ca
+        value: https://test.dashboard.stms.gov.bc.ca
 
   - target:
       kind: Route
@@ -82,13 +82,13 @@ patches:
       - op: replace
         path: /spec/host
         value: test-hsb.apps.emerald.devops.gov.bc.ca
-  # - target:
-  #     kind: Route
-  #     name: dashboard-tls
-  #   patch: |-
-  #     - op: replace
-  #       path: /spec/host
-  #       value: hsb.gov.bc.ca
+  - target:
+      kind: Route
+      name: dashboard-stms
+    patch: |-
+      - op: replace
+        path: /spec/host
+        value: test.dashboard.stms.gov.bc.ca
 
   - target:
       kind: DeploymentConfig


### PR DESCRIPTION
Updating the kustomize base and overlays to add support for the vanity TLS URL.
Updating the configuration to use the vanity TLS URL instead of the default apps domain.